### PR TITLE
Add Float type sum logic

### DIFF
--- a/packages/sqlite-web-core/src/database_functions/bigint_sum.rs
+++ b/packages/sqlite-web-core/src/database_functions/bigint_sum.rs
@@ -115,7 +115,16 @@ pub unsafe extern "C" fn bigint_sum_final(context: *mut sqlite3_context) {
     let aggregate_context = sqlite3_aggregate_context(context, 0);
 
     if aggregate_context.is_null() {
-        sqlite3_result_null(context);
+        let zero_result = CString::new("0").unwrap();
+        sqlite3_result_text(
+            context,
+            zero_result.as_ptr(),
+            zero_result.as_bytes().len() as c_int,
+            Some(std::mem::transmute::<
+                isize,
+                unsafe extern "C" fn(*mut std::ffi::c_void),
+            >(-1isize)),
+        );
         return;
     }
 

--- a/packages/sqlite-web-core/src/database_functions/bigint_sum.rs
+++ b/packages/sqlite-web-core/src/database_functions/bigint_sum.rs
@@ -112,21 +112,10 @@ pub unsafe extern "C" fn bigint_sum_step(
 
 // Aggregate function final - called to return the final result
 pub unsafe extern "C" fn bigint_sum_final(context: *mut sqlite3_context) {
-    let aggregate_context =
-        sqlite3_aggregate_context(context, std::mem::size_of::<BigIntSumContext>() as c_int);
+    let aggregate_context = sqlite3_aggregate_context(context, 0);
 
     if aggregate_context.is_null() {
-        // No values were processed, return 0
-        let zero_result = CString::new("0").unwrap();
-        sqlite3_result_text(
-            context,
-            zero_result.as_ptr(),
-            zero_result.as_bytes().len() as c_int,
-            Some(std::mem::transmute::<
-                isize,
-                unsafe extern "C" fn(*mut std::ffi::c_void),
-            >(-1isize)), // SQLITE_TRANSIENT
-        );
+        sqlite3_result_null(context);
         return;
     }
 
@@ -138,6 +127,7 @@ pub unsafe extern "C" fn bigint_sum_final(context: *mut sqlite3_context) {
         Err(e) => {
             let error_msg = format!("Failed to create result string: {}\0", e);
             sqlite3_result_error(context, error_msg.as_ptr() as *const c_char, -1);
+            std::ptr::drop_in_place(sum_context);
             return;
         }
     };
@@ -151,6 +141,8 @@ pub unsafe extern "C" fn bigint_sum_final(context: *mut sqlite3_context) {
             unsafe extern "C" fn(*mut std::ffi::c_void),
         >(-1isize)), // SQLITE_TRANSIENT
     );
+
+    std::ptr::drop_in_place(sum_context);
 }
 
 #[cfg(test)]

--- a/packages/sqlite-web-core/src/database_functions/float_sum.rs
+++ b/packages/sqlite-web-core/src/database_functions/float_sum.rs
@@ -7,7 +7,7 @@ pub struct FloatSumContext {
 impl FloatSumContext {
     fn new() -> Self {
         Self {
-            total: Float::parse("0".to_string()).unwrap(),
+            total: Float::default(),
         }
     }
 
@@ -96,29 +96,17 @@ pub unsafe extern "C" fn float_sum_step(
     // Add this value to the running total
     if let Err(e) = (*sum_context).add_value(&value_str) {
         let error_msg = format!("{}\0", e);
-        sqlite3_result_error(context, error_msg.as_ptr() as *const c_char, -1);
+        sqlite3_result_error(context, error_msg.as_ptr() as *const c_char, -1)
     }
 }
 
 // Aggregate function final - called to return the final result
 pub unsafe extern "C" fn float_sum_final(context: *mut sqlite3_context) {
-    let aggregate_context =
-        sqlite3_aggregate_context(context, std::mem::size_of::<FloatSumContext>() as c_int);
+    let aggregate_context = sqlite3_aggregate_context(context, 0);
 
     if aggregate_context.is_null() {
-        // No values were processed, return 0 in hex format
-        let zero_result =
-            CString::new("0x0000000000000000000000000000000000000000000000000000000000000000")
-                .unwrap();
-        sqlite3_result_text(
-            context,
-            zero_result.as_ptr(),
-            zero_result.as_bytes().len() as c_int,
-            Some(std::mem::transmute::<
-                isize,
-                unsafe extern "C" fn(*mut std::ffi::c_void),
-            >(-1isize)), // SQLITE_TRANSIENT
-        );
+        // No rows were processed; propagate NULL like SQLite's SUM.
+        sqlite3_result_null(context);
         return;
     }
 
@@ -128,6 +116,7 @@ pub unsafe extern "C" fn float_sum_final(context: *mut sqlite3_context) {
         Err(e) => {
             let error_msg = format!("{}\0", e);
             sqlite3_result_error(context, error_msg.as_ptr() as *const c_char, -1);
+            std::ptr::drop_in_place(sum_context);
             return;
         }
     };
@@ -137,6 +126,7 @@ pub unsafe extern "C" fn float_sum_final(context: *mut sqlite3_context) {
         Err(e) => {
             let error_msg = format!("Failed to create result string: {}\0", e);
             sqlite3_result_error(context, error_msg.as_ptr() as *const c_char, -1);
+            std::ptr::drop_in_place(sum_context);
             return;
         }
     };
@@ -150,6 +140,8 @@ pub unsafe extern "C" fn float_sum_final(context: *mut sqlite3_context) {
             unsafe extern "C" fn(*mut std::ffi::c_void),
         >(-1isize)), // SQLITE_TRANSIENT
     );
+
+    std::ptr::drop_in_place(sum_context);
 }
 
 #[cfg(test)]
@@ -172,14 +164,14 @@ mod tests {
         let mut context = FloatSumContext::new();
 
         assert!(context
-            .add_value("0xffffffff00000000000000000000000000000000000000000000000000000001")
+            .add_value(Float::parse("0.1".to_string()).unwrap().as_hex().as_str())
             .is_ok()); // 0.1
         let result_hex = context.get_result().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "0.1");
 
         assert!(context
-            .add_value("0xffffffff00000000000000000000000000000000000000000000000000000005")
+            .add_value(Float::parse("0.5".to_string()).unwrap().as_hex().as_str())
             .is_ok()); // 0.5
         let result_hex = context.get_result().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
@@ -231,15 +223,15 @@ mod tests {
     fn test_float_sum_context_large_hex_values() {
         let mut context = FloatSumContext::new();
 
-        let large_hex1 = "0xfffffffe00000000000000000000000000000000000000000000000000002729"; // 100.25
-        let large_hex2 = "0xfffffffd0000000000000000000000000000000000000000000000000001e240"; // 123.456
+        let large_hex1 = Float::parse("100.25".to_string()).unwrap();
+        let large_hex2 = Float::parse("123.456".to_string()).unwrap(); // 123.456
 
-        assert!(context.add_value(large_hex1).is_ok());
+        assert!(context.add_value(&large_hex1.as_hex()).is_ok());
         let result_hex = context.get_result().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "100.25");
 
-        assert!(context.add_value(large_hex2).is_ok());
+        assert!(context.add_value(&large_hex2.as_hex()).is_ok());
         let result_hex = context.get_result().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "223.706"); // 100.25 + 123.456 = 223.706
@@ -250,14 +242,14 @@ mod tests {
         let mut context = FloatSumContext::new();
 
         assert!(context
-            .add_value("0x0000000000000000000000000000000000000000000000000000000000000000")
+            .add_value(Float::default().as_hex().as_str())
             .is_ok()); // 0
         let result_hex = context.get_result().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "0");
 
         assert!(context
-            .add_value("0xffffffff00000000000000000000000000000000000000000000000000000001")
+            .add_value(Float::parse("0.1".to_string()).unwrap().as_hex().as_str())
             .is_ok()); // 0.1
         let result_hex = context.get_result().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
@@ -269,14 +261,14 @@ mod tests {
         let mut context = FloatSumContext::new();
 
         assert!(context
-            .add_value("0xFfFfFfFf0000000000000000000000000000000000000000000000000000000F")
+            .add_value(Float::parse("1.5".to_string()).unwrap().as_hex().as_str())
             .is_ok()); // 1.5
         let result_hex = context.get_result().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "1.5");
 
         assert!(context
-            .add_value("0xFfFfFfFe000000000000000000000000000000000000000000000000000000E1")
+            .add_value(Float::parse("2.25".to_string()).unwrap().as_hex().as_str())
             .is_ok()); // 2.25
         let result_hex = context.get_result().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
@@ -296,14 +288,20 @@ mod tests {
         let mut context = FloatSumContext::new();
 
         assert!(context
-            .add_value("  0x000000000000000000000000000000000000000000000000000000000000000a  ")
+            .add_value(&format!(
+                " {} ",
+                Float::parse("10".to_string()).unwrap().as_hex()
+            ))
             .is_ok()); // 10
         let result_hex = context.get_result().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "10");
 
         assert!(context
-            .add_value("\t0x0000000000000000000000000000000000000000000000000000000000000014\n")
+            .add_value(&format!(
+                "\t{}\n",
+                Float::parse("20".to_string()).unwrap().as_hex()
+            ))
             .is_ok()); // 20
         let result_hex = context.get_result().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
@@ -315,15 +313,15 @@ mod tests {
         let mut context = FloatSumContext::new();
 
         let high_precision_hex_values = vec![
-            "0xffffffee0000000000000000000000000000000000000010450cb5d3cf60f34e", // 300.123456789012345678
-            "0xffffffee0000000000000000000000000000000000000010510af4e77328b478", // 300.987654321098765432
-            "0xffffffee00000000000000000000000000000000000000104b0bd55dbf1238e3", // 300.555555555555555555
-            "0xffffffee00000000000000000000000000000000000000104e21534cc7d31c71", // 300.777777777777777777
-            "0xffffffee00000000000000000000000000000000000000105136d13bd093ffff", // 300.999999999999999999
+            Float::parse("300.123456789012345678".to_string()).unwrap(),
+            Float::parse("300.987654321098765432".to_string()).unwrap(),
+            Float::parse("300.555555555555555555".to_string()).unwrap(),
+            Float::parse("300.777777777777777777".to_string()).unwrap(),
+            Float::parse("300.999999999999999999".to_string()).unwrap(),
         ];
 
         for hex_val in high_precision_hex_values {
-            assert!(context.add_value(hex_val).is_ok());
+            assert!(context.add_value(&hex_val.as_hex()).is_ok());
         }
 
         let result_hex = context.get_result().unwrap();

--- a/packages/sqlite-web-core/src/database_functions/float_sum.rs
+++ b/packages/sqlite-web-core/src/database_functions/float_sum.rs
@@ -1,0 +1,325 @@
+use super::*;
+
+pub struct FloatSumContext {
+    total: Float,
+}
+
+impl FloatSumContext {
+    fn new() -> Self {
+        Self {
+            total: Float::parse("0".to_string()).unwrap(),
+        }
+    }
+
+    fn add_value(&mut self, value_str: &str) -> Result<(), String> {
+        let trimmed = value_str.trim();
+
+        if trimmed.is_empty() {
+            return Err("Empty string is not a valid hex number".to_string());
+        }
+
+        let float_value = Float::from_hex(trimmed)
+            .map_err(|e| format!("Failed to parse hex number '{}': {}", trimmed, e))?;
+
+        self.total = self.total.add(float_value).map_err(|e| {
+            format!(
+                "Float overflow when adding {} to running total: {}",
+                trimmed, e
+            )
+        })?;
+
+        Ok(())
+    }
+
+    fn get_result(&self) -> Result<String, String> {
+        self.total
+            .format()
+            .map_err(|e| format!("Failed to format float result: {}", e))
+    }
+}
+
+// Aggregate function step - called for each row
+pub unsafe extern "C" fn float_sum_step(
+    context: *mut sqlite3_context,
+    argc: c_int,
+    argv: *mut *mut sqlite3_value,
+) {
+    if argc != 1 {
+        sqlite3_result_error(
+            context,
+            c"FLOAT_SUM() requires exactly 1 argument".as_ptr(),
+            -1,
+        );
+        return;
+    }
+
+    // Get the text value
+    let value_ptr = sqlite3_value_text(*argv);
+    if value_ptr.is_null() {
+        return;
+    }
+
+    let value_str = CStr::from_ptr(value_ptr as *const c_char).to_string_lossy();
+
+    // Get or create the aggregate context
+    let aggregate_context =
+        sqlite3_aggregate_context(context, std::mem::size_of::<FloatSumContext>() as c_int);
+    if aggregate_context.is_null() {
+        sqlite3_result_error(
+            context,
+            c"Failed to allocate aggregate context".as_ptr(),
+            -1,
+        );
+        return;
+    }
+
+    // Cast to our context type
+    let sum_context = aggregate_context as *mut FloatSumContext;
+
+    // SQLite's sqlite3_aggregate_context allocates zeroed memory on first call
+    // We can determine if this is the first call by checking if the memory is all zeros
+    let mut is_uninitialized = true;
+    let bytes = std::slice::from_raw_parts(
+        aggregate_context as *const u8,
+        std::mem::size_of::<FloatSumContext>(),
+    );
+    for &byte in bytes {
+        if byte != 0 {
+            is_uninitialized = false;
+            break;
+        }
+    }
+
+    if is_uninitialized {
+        std::ptr::write(sum_context, FloatSumContext::new());
+    }
+
+    // Add this value to the running total
+    if let Err(e) = (*sum_context).add_value(&value_str) {
+        let error_msg = format!("{}\0", e);
+        sqlite3_result_error(context, error_msg.as_ptr() as *const c_char, -1);
+    }
+}
+
+// Aggregate function final - called to return the final result
+pub unsafe extern "C" fn float_sum_final(context: *mut sqlite3_context) {
+    let aggregate_context =
+        sqlite3_aggregate_context(context, std::mem::size_of::<FloatSumContext>() as c_int);
+
+    if aggregate_context.is_null() {
+        // No values were processed, return 0
+        let zero_result = CString::new("0").unwrap();
+        sqlite3_result_text(
+            context,
+            zero_result.as_ptr(),
+            zero_result.as_bytes().len() as c_int,
+            Some(std::mem::transmute::<
+                isize,
+                unsafe extern "C" fn(*mut std::ffi::c_void),
+            >(-1isize)), // SQLITE_TRANSIENT
+        );
+        return;
+    }
+
+    let sum_context = aggregate_context as *mut FloatSumContext;
+    let result_str = match (*sum_context).get_result() {
+        Ok(s) => s,
+        Err(e) => {
+            let error_msg = format!("{}\0", e);
+            sqlite3_result_error(context, error_msg.as_ptr() as *const c_char, -1);
+            return;
+        }
+    };
+
+    let result_cstring = match CString::new(result_str) {
+        Ok(s) => s,
+        Err(e) => {
+            let error_msg = format!("Failed to create result string: {}\0", e);
+            sqlite3_result_error(context, error_msg.as_ptr() as *const c_char, -1);
+            return;
+        }
+    };
+
+    sqlite3_result_text(
+        context,
+        result_cstring.as_ptr(),
+        result_cstring.as_bytes().len() as c_int,
+        Some(std::mem::transmute::<
+            isize,
+            unsafe extern "C" fn(*mut std::ffi::c_void),
+        >(-1isize)), // SQLITE_TRANSIENT
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::*;
+
+    #[wasm_bindgen_test]
+    fn test_float_sum_context_new() {
+        let context = FloatSumContext::new();
+        let zero = Float::parse("0".to_string()).unwrap();
+        assert_eq!(context.total.format().unwrap(), zero.format().unwrap());
+        assert_eq!(context.get_result().unwrap(), "0");
+    }
+
+    #[wasm_bindgen_test]
+    fn test_float_sum_context_add_hex_values() {
+        let mut context = FloatSumContext::new();
+
+        assert!(context
+            .add_value("0xffffffff00000000000000000000000000000000000000000000000000000001")
+            .is_ok()); // 0.1
+        assert_eq!(context.get_result().unwrap(), "0.1");
+
+        assert!(context
+            .add_value("0xffffffff00000000000000000000000000000000000000000000000000000005")
+            .is_ok()); // 0.5
+        assert_eq!(context.get_result().unwrap(), "0.6"); // 0.1 + 0.5 = 0.6
+    }
+
+    #[wasm_bindgen_test]
+    fn test_float_sum_context_add_hex_without_prefix() {
+        let mut context = FloatSumContext::new();
+
+        assert!(context
+            .add_value("ffffffff0000000000000000000000000000000000000000000000000000000f")
+            .is_ok()); // 1.5
+        assert_eq!(context.get_result().unwrap(), "1.5");
+
+        assert!(context
+            .add_value("fffffffe000000000000000000000000000000000000000000000000000000e1")
+            .is_ok()); // 2.25
+        assert_eq!(context.get_result().unwrap(), "3.75"); // 1.5 + 2.25 = 3.75
+    }
+
+    #[wasm_bindgen_test]
+    fn test_float_sum_context_add_uppercase_hex() {
+        let mut context = FloatSumContext::new();
+
+        assert!(context
+            .add_value("0XFFFFFFFB0000000000000000000000000000000000000000000000000004CB2F")
+            .is_err()); // Should fail - uppercase 0X not supported
+        assert!(context
+            .add_value("0XFFFFFFFF00000000000000000000000000000000000000000000000000000069")
+            .is_err()); // Should fail - uppercase 0X not supported
+    }
+
+    #[wasm_bindgen_test]
+    fn test_float_sum_context_invalid_input() {
+        let mut context = FloatSumContext::new();
+
+        assert!(context.add_value("not_hex").is_err());
+        assert!(context.add_value("0xGHI").is_err());
+        assert!(context.add_value("").is_err());
+        assert!(context.add_value("   ").is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_float_sum_context_large_hex_values() {
+        let mut context = FloatSumContext::new();
+
+        let large_hex1 = "0xfffffffe00000000000000000000000000000000000000000000000000002729"; // 100.25
+        let large_hex2 = "0xfffffffd0000000000000000000000000000000000000000000000000001e240"; // 123.456
+
+        assert!(context.add_value(large_hex1).is_ok());
+        assert_eq!(context.get_result().unwrap(), "100.25");
+
+        assert!(context.add_value(large_hex2).is_ok());
+        assert_eq!(context.get_result().unwrap(), "223.706"); // 100.25 + 123.456 = 223.706
+    }
+
+    #[wasm_bindgen_test]
+    fn test_float_sum_context_zero_values() {
+        let mut context = FloatSumContext::new();
+
+        assert!(context
+            .add_value("0x0000000000000000000000000000000000000000000000000000000000000000")
+            .is_ok()); // 0
+        assert_eq!(context.get_result().unwrap(), "0");
+
+        assert!(context
+            .add_value("0xffffffff00000000000000000000000000000000000000000000000000000001")
+            .is_ok()); // 0.1
+        assert_eq!(context.get_result().unwrap(), "0.1"); // 0 + 0.1 = 0.1
+    }
+
+    #[wasm_bindgen_test]
+    fn test_float_sum_context_mixed_case_hex() {
+        let mut context = FloatSumContext::new();
+
+        assert!(context
+            .add_value("0xFfFfFfFf0000000000000000000000000000000000000000000000000000000F")
+            .is_ok()); // 1.5
+        assert_eq!(context.get_result().unwrap(), "1.5");
+
+        assert!(context
+            .add_value("0xFfFfFfFe000000000000000000000000000000000000000000000000000000E1")
+            .is_ok()); // 2.25
+        assert_eq!(context.get_result().unwrap(), "3.75"); // 1.5 + 2.25 = 3.75
+    }
+
+    #[wasm_bindgen_test]
+    fn test_float_sum_context_edge_case_hex() {
+        let mut context = FloatSumContext::new();
+
+        assert!(context.add_value("0x0").is_err()); // Should fail - too short
+        assert!(context.add_value("0xF").is_err()); // Should fail - too short
+    }
+
+    #[wasm_bindgen_test]
+    fn test_float_sum_context_whitespace_handling() {
+        let mut context = FloatSumContext::new();
+
+        assert!(context
+            .add_value("  0x000000000000000000000000000000000000000000000000000000000000000a  ")
+            .is_ok()); // 10
+        assert_eq!(context.get_result().unwrap(), "10");
+
+        assert!(context
+            .add_value("\t0x0000000000000000000000000000000000000000000000000000000000000014\n")
+            .is_ok()); // 20
+        assert_eq!(context.get_result().unwrap(), "30"); // 10 + 20 = 30
+    }
+
+    #[wasm_bindgen_test]
+    fn test_float_sum_context_high_precision_decimals() {
+        let mut context = FloatSumContext::new();
+
+        let high_precision_hex_values = vec![
+            "0xffffffee0000000000000000000000000000000000000010450cb5d3cf60f34e", // 300.123456789012345678
+            "0xffffffee0000000000000000000000000000000000000010510af4e77328b478", // 300.987654321098765432
+            "0xffffffee00000000000000000000000000000000000000104b0bd55dbf1238e3", // 300.555555555555555555
+            "0xffffffee00000000000000000000000000000000000000104e21534cc7d31c71", // 300.777777777777777777
+            "0xffffffee00000000000000000000000000000000000000105136d13bd093ffff", // 300.999999999999999999
+        ];
+
+        for hex_val in high_precision_hex_values {
+            assert!(context.add_value(hex_val).is_ok());
+        }
+
+        let result = context.get_result().unwrap();
+        assert_eq!(result, "1503.444444443444444441"); // Sum of all 5 high-precision values
+    }
+
+    #[wasm_bindgen_test]
+    fn test_float_sum_context_mixed_precision_values() {
+        let mut context = FloatSumContext::new();
+
+        assert!(context
+            .add_value("0xffffffee00000000000000000000000000000000000000000f9751ff4d94f34e")
+            .is_ok()); // 1.123456789012345678
+        assert_eq!(context.get_result().unwrap(), "1.123456789012345678");
+
+        assert!(context
+            .add_value("0xffffffee0000000000000000000000000000000000000000297647c698c0b478")
+            .is_ok()); // 2.987654321098765432
+        assert_eq!(context.get_result().unwrap(), "4.11111111011111111"); // 1.123456789012345678 + 2.987654321098765432
+
+        assert!(context
+            .add_value("0x0000000000000000000000000000000000000000000000000000000000000064")
+            .is_ok()); // 100
+        assert_eq!(context.get_result().unwrap(), "104.11111111011111111"); // 4.11111111011111111 + 100
+    }
+}

--- a/packages/sqlite-web-core/src/database_functions/float_sum.rs
+++ b/packages/sqlite-web-core/src/database_functions/float_sum.rs
@@ -107,10 +107,9 @@ pub unsafe extern "C" fn float_sum_final(context: *mut sqlite3_context) {
 
     if aggregate_context.is_null() {
         // No values were processed, return 0 in hex format
-        let zero_result = CString::new(
-            "0x0000000000000000000000000000000000000000000000000000000000000000",
-        )
-        .unwrap();
+        let zero_result =
+            CString::new("0x0000000000000000000000000000000000000000000000000000000000000000")
+                .unwrap();
         sqlite3_result_text(
             context,
             zero_result.as_ptr(),

--- a/packages/sqlite-web-core/src/database_functions/float_sum.rs
+++ b/packages/sqlite-web-core/src/database_functions/float_sum.rs
@@ -21,7 +21,7 @@ impl FloatSumContext {
         let float_value = Float::from_hex(trimmed)
             .map_err(|e| format!("Failed to parse hex number '{}': {}", trimmed, e))?;
 
-        self.total = self.total.add(float_value).map_err(|e| {
+        self.total = (self.total + float_value).map_err(|e| {
             format!(
                 "Float overflow when adding {} to running total: {}",
                 trimmed, e
@@ -31,14 +31,14 @@ impl FloatSumContext {
         Ok(())
     }
 
-    fn get_result(&self) -> Result<String, String> {
+    fn get_total_as_hex(&self) -> Result<String, String> {
         // Return the hex representation of the accumulated Float
         Ok(self.total.as_hex())
     }
 }
 
 // Aggregate function step - called for each row
-pub unsafe extern "C" fn float_sum_step(
+pub(crate) unsafe extern "C" fn float_sum_step(
     context: *mut sqlite3_context,
     argc: c_int,
     argv: *mut *mut sqlite3_value,
@@ -77,17 +77,11 @@ pub unsafe extern "C" fn float_sum_step(
 
     // SQLite's sqlite3_aggregate_context allocates zeroed memory on first call
     // We can determine if this is the first call by checking if the memory is all zeros
-    let mut is_uninitialized = true;
     let bytes = std::slice::from_raw_parts(
         aggregate_context as *const u8,
         std::mem::size_of::<FloatSumContext>(),
     );
-    for &byte in bytes {
-        if byte != 0 {
-            is_uninitialized = false;
-            break;
-        }
-    }
+    let is_uninitialized = bytes.iter().all(|&b| b == 0);
 
     if is_uninitialized {
         std::ptr::write(sum_context, FloatSumContext::new());
@@ -101,17 +95,27 @@ pub unsafe extern "C" fn float_sum_step(
 }
 
 // Aggregate function final - called to return the final result
-pub unsafe extern "C" fn float_sum_final(context: *mut sqlite3_context) {
+pub(crate) unsafe extern "C" fn float_sum_final(context: *mut sqlite3_context) {
     let aggregate_context = sqlite3_aggregate_context(context, 0);
 
     if aggregate_context.is_null() {
-        // No rows were processed; propagate NULL like SQLite's SUM.
-        sqlite3_result_null(context);
+        // No rows were processed; surface the canonical zero hex string derived from Float::default().
+        let zero_hex = Float::default().as_hex();
+        let zero_result = CString::new(zero_hex).unwrap();
+        sqlite3_result_text(
+            context,
+            zero_result.as_ptr(),
+            zero_result.as_bytes().len() as c_int,
+            Some(std::mem::transmute::<
+                isize,
+                unsafe extern "C" fn(*mut std::ffi::c_void),
+            >(-1isize)),
+        );
         return;
     }
 
     let sum_context = aggregate_context as *mut FloatSumContext;
-    let result_str = match (*sum_context).get_result() {
+    let result_str = match (*sum_context).get_total_as_hex() {
         Ok(s) => s,
         Err(e) => {
             let error_msg = format!("{}\0", e);
@@ -154,7 +158,7 @@ mod tests {
         let context = FloatSumContext::new();
         let zero = Float::parse("0".to_string()).unwrap();
         assert_eq!(context.total.format().unwrap(), zero.format().unwrap());
-        let result_hex = context.get_result().unwrap();
+        let result_hex = context.get_total_as_hex().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "0");
     }
@@ -166,14 +170,14 @@ mod tests {
         assert!(context
             .add_value(Float::parse("0.1".to_string()).unwrap().as_hex().as_str())
             .is_ok()); // 0.1
-        let result_hex = context.get_result().unwrap();
+        let result_hex = context.get_total_as_hex().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "0.1");
 
         assert!(context
             .add_value(Float::parse("0.5".to_string()).unwrap().as_hex().as_str())
             .is_ok()); // 0.5
-        let result_hex = context.get_result().unwrap();
+        let result_hex = context.get_total_as_hex().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "0.6"); // 0.1 + 0.5 = 0.6
     }
@@ -185,14 +189,14 @@ mod tests {
         assert!(context
             .add_value("ffffffff0000000000000000000000000000000000000000000000000000000f")
             .is_ok()); // 1.5
-        let result_hex = context.get_result().unwrap();
+        let result_hex = context.get_total_as_hex().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "1.5");
 
         assert!(context
             .add_value("fffffffe000000000000000000000000000000000000000000000000000000e1")
             .is_ok()); // 2.25
-        let result_hex = context.get_result().unwrap();
+        let result_hex = context.get_total_as_hex().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "3.75"); // 1.5 + 2.25 = 3.75
     }
@@ -227,12 +231,12 @@ mod tests {
         let large_hex2 = Float::parse("123.456".to_string()).unwrap(); // 123.456
 
         assert!(context.add_value(&large_hex1.as_hex()).is_ok());
-        let result_hex = context.get_result().unwrap();
+        let result_hex = context.get_total_as_hex().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "100.25");
 
         assert!(context.add_value(&large_hex2.as_hex()).is_ok());
-        let result_hex = context.get_result().unwrap();
+        let result_hex = context.get_total_as_hex().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "223.706"); // 100.25 + 123.456 = 223.706
     }
@@ -244,14 +248,14 @@ mod tests {
         assert!(context
             .add_value(Float::default().as_hex().as_str())
             .is_ok()); // 0
-        let result_hex = context.get_result().unwrap();
+        let result_hex = context.get_total_as_hex().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "0");
 
         assert!(context
             .add_value(Float::parse("0.1".to_string()).unwrap().as_hex().as_str())
             .is_ok()); // 0.1
-        let result_hex = context.get_result().unwrap();
+        let result_hex = context.get_total_as_hex().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "0.1"); // 0 + 0.1 = 0.1
     }
@@ -263,14 +267,14 @@ mod tests {
         assert!(context
             .add_value(Float::parse("1.5".to_string()).unwrap().as_hex().as_str())
             .is_ok()); // 1.5
-        let result_hex = context.get_result().unwrap();
+        let result_hex = context.get_total_as_hex().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "1.5");
 
         assert!(context
             .add_value(Float::parse("2.25".to_string()).unwrap().as_hex().as_str())
             .is_ok()); // 2.25
-        let result_hex = context.get_result().unwrap();
+        let result_hex = context.get_total_as_hex().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "3.75"); // 1.5 + 2.25 = 3.75
     }
@@ -293,7 +297,7 @@ mod tests {
                 Float::parse("10".to_string()).unwrap().as_hex()
             ))
             .is_ok()); // 10
-        let result_hex = context.get_result().unwrap();
+        let result_hex = context.get_total_as_hex().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "10");
 
@@ -303,7 +307,7 @@ mod tests {
                 Float::parse("20".to_string()).unwrap().as_hex()
             ))
             .is_ok()); // 20
-        let result_hex = context.get_result().unwrap();
+        let result_hex = context.get_total_as_hex().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "30"); // 10 + 20 = 30
     }
@@ -324,7 +328,7 @@ mod tests {
             assert!(context.add_value(&hex_val.as_hex()).is_ok());
         }
 
-        let result_hex = context.get_result().unwrap();
+        let result_hex = context.get_total_as_hex().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "1503.444444443444444441"); // Sum of all 5 high-precision values
     }
@@ -334,23 +338,33 @@ mod tests {
         let mut context = FloatSumContext::new();
 
         assert!(context
-            .add_value("0xffffffee00000000000000000000000000000000000000000f9751ff4d94f34e")
+            .add_value(
+                Float::parse("1.123456789012345678".to_string())
+                    .unwrap()
+                    .as_hex()
+                    .as_str()
+            )
             .is_ok()); // 1.123456789012345678
-        let result_hex = context.get_result().unwrap();
+        let result_hex = context.get_total_as_hex().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "1.123456789012345678");
 
         assert!(context
-            .add_value("0xffffffee0000000000000000000000000000000000000000297647c698c0b478")
+            .add_value(
+                Float::parse("2.987654321098765432".to_string())
+                    .unwrap()
+                    .as_hex()
+                    .as_str()
+            )
             .is_ok()); // 2.987654321098765432
-        let result_hex = context.get_result().unwrap();
+        let result_hex = context.get_total_as_hex().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "4.11111111011111111"); // 1.123456789012345678 + 2.987654321098765432
 
         assert!(context
-            .add_value("0x0000000000000000000000000000000000000000000000000000000000000064")
+            .add_value(Float::parse("100".to_string()).unwrap().as_hex().as_str())
             .is_ok()); // 100
-        let result_hex = context.get_result().unwrap();
+        let result_hex = context.get_total_as_hex().unwrap();
         let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
         assert_eq!(result_decimal, "104.11111111011111111"); // 4.11111111011111111 + 100
     }

--- a/packages/sqlite-web-core/src/database_functions/float_sum.rs
+++ b/packages/sqlite-web-core/src/database_functions/float_sum.rs
@@ -32,9 +32,8 @@ impl FloatSumContext {
     }
 
     fn get_result(&self) -> Result<String, String> {
-        self.total
-            .format()
-            .map_err(|e| format!("Failed to format float result: {}", e))
+        // Return the hex representation of the accumulated Float
+        Ok(self.total.as_hex())
     }
 }
 
@@ -107,8 +106,11 @@ pub unsafe extern "C" fn float_sum_final(context: *mut sqlite3_context) {
         sqlite3_aggregate_context(context, std::mem::size_of::<FloatSumContext>() as c_int);
 
     if aggregate_context.is_null() {
-        // No values were processed, return 0
-        let zero_result = CString::new("0").unwrap();
+        // No values were processed, return 0 in hex format
+        let zero_result = CString::new(
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+        )
+        .unwrap();
         sqlite3_result_text(
             context,
             zero_result.as_ptr(),
@@ -161,7 +163,9 @@ mod tests {
         let context = FloatSumContext::new();
         let zero = Float::parse("0".to_string()).unwrap();
         assert_eq!(context.total.format().unwrap(), zero.format().unwrap());
-        assert_eq!(context.get_result().unwrap(), "0");
+        let result_hex = context.get_result().unwrap();
+        let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
+        assert_eq!(result_decimal, "0");
     }
 
     #[wasm_bindgen_test]
@@ -171,12 +175,16 @@ mod tests {
         assert!(context
             .add_value("0xffffffff00000000000000000000000000000000000000000000000000000001")
             .is_ok()); // 0.1
-        assert_eq!(context.get_result().unwrap(), "0.1");
+        let result_hex = context.get_result().unwrap();
+        let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
+        assert_eq!(result_decimal, "0.1");
 
         assert!(context
             .add_value("0xffffffff00000000000000000000000000000000000000000000000000000005")
             .is_ok()); // 0.5
-        assert_eq!(context.get_result().unwrap(), "0.6"); // 0.1 + 0.5 = 0.6
+        let result_hex = context.get_result().unwrap();
+        let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
+        assert_eq!(result_decimal, "0.6"); // 0.1 + 0.5 = 0.6
     }
 
     #[wasm_bindgen_test]
@@ -186,12 +194,16 @@ mod tests {
         assert!(context
             .add_value("ffffffff0000000000000000000000000000000000000000000000000000000f")
             .is_ok()); // 1.5
-        assert_eq!(context.get_result().unwrap(), "1.5");
+        let result_hex = context.get_result().unwrap();
+        let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
+        assert_eq!(result_decimal, "1.5");
 
         assert!(context
             .add_value("fffffffe000000000000000000000000000000000000000000000000000000e1")
             .is_ok()); // 2.25
-        assert_eq!(context.get_result().unwrap(), "3.75"); // 1.5 + 2.25 = 3.75
+        let result_hex = context.get_result().unwrap();
+        let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
+        assert_eq!(result_decimal, "3.75"); // 1.5 + 2.25 = 3.75
     }
 
     #[wasm_bindgen_test]
@@ -224,10 +236,14 @@ mod tests {
         let large_hex2 = "0xfffffffd0000000000000000000000000000000000000000000000000001e240"; // 123.456
 
         assert!(context.add_value(large_hex1).is_ok());
-        assert_eq!(context.get_result().unwrap(), "100.25");
+        let result_hex = context.get_result().unwrap();
+        let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
+        assert_eq!(result_decimal, "100.25");
 
         assert!(context.add_value(large_hex2).is_ok());
-        assert_eq!(context.get_result().unwrap(), "223.706"); // 100.25 + 123.456 = 223.706
+        let result_hex = context.get_result().unwrap();
+        let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
+        assert_eq!(result_decimal, "223.706"); // 100.25 + 123.456 = 223.706
     }
 
     #[wasm_bindgen_test]
@@ -237,12 +253,16 @@ mod tests {
         assert!(context
             .add_value("0x0000000000000000000000000000000000000000000000000000000000000000")
             .is_ok()); // 0
-        assert_eq!(context.get_result().unwrap(), "0");
+        let result_hex = context.get_result().unwrap();
+        let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
+        assert_eq!(result_decimal, "0");
 
         assert!(context
             .add_value("0xffffffff00000000000000000000000000000000000000000000000000000001")
             .is_ok()); // 0.1
-        assert_eq!(context.get_result().unwrap(), "0.1"); // 0 + 0.1 = 0.1
+        let result_hex = context.get_result().unwrap();
+        let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
+        assert_eq!(result_decimal, "0.1"); // 0 + 0.1 = 0.1
     }
 
     #[wasm_bindgen_test]
@@ -252,12 +272,16 @@ mod tests {
         assert!(context
             .add_value("0xFfFfFfFf0000000000000000000000000000000000000000000000000000000F")
             .is_ok()); // 1.5
-        assert_eq!(context.get_result().unwrap(), "1.5");
+        let result_hex = context.get_result().unwrap();
+        let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
+        assert_eq!(result_decimal, "1.5");
 
         assert!(context
             .add_value("0xFfFfFfFe000000000000000000000000000000000000000000000000000000E1")
             .is_ok()); // 2.25
-        assert_eq!(context.get_result().unwrap(), "3.75"); // 1.5 + 2.25 = 3.75
+        let result_hex = context.get_result().unwrap();
+        let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
+        assert_eq!(result_decimal, "3.75"); // 1.5 + 2.25 = 3.75
     }
 
     #[wasm_bindgen_test]
@@ -275,12 +299,16 @@ mod tests {
         assert!(context
             .add_value("  0x000000000000000000000000000000000000000000000000000000000000000a  ")
             .is_ok()); // 10
-        assert_eq!(context.get_result().unwrap(), "10");
+        let result_hex = context.get_result().unwrap();
+        let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
+        assert_eq!(result_decimal, "10");
 
         assert!(context
             .add_value("\t0x0000000000000000000000000000000000000000000000000000000000000014\n")
             .is_ok()); // 20
-        assert_eq!(context.get_result().unwrap(), "30"); // 10 + 20 = 30
+        let result_hex = context.get_result().unwrap();
+        let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
+        assert_eq!(result_decimal, "30"); // 10 + 20 = 30
     }
 
     #[wasm_bindgen_test]
@@ -299,8 +327,9 @@ mod tests {
             assert!(context.add_value(hex_val).is_ok());
         }
 
-        let result = context.get_result().unwrap();
-        assert_eq!(result, "1503.444444443444444441"); // Sum of all 5 high-precision values
+        let result_hex = context.get_result().unwrap();
+        let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
+        assert_eq!(result_decimal, "1503.444444443444444441"); // Sum of all 5 high-precision values
     }
 
     #[wasm_bindgen_test]
@@ -310,16 +339,22 @@ mod tests {
         assert!(context
             .add_value("0xffffffee00000000000000000000000000000000000000000f9751ff4d94f34e")
             .is_ok()); // 1.123456789012345678
-        assert_eq!(context.get_result().unwrap(), "1.123456789012345678");
+        let result_hex = context.get_result().unwrap();
+        let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
+        assert_eq!(result_decimal, "1.123456789012345678");
 
         assert!(context
             .add_value("0xffffffee0000000000000000000000000000000000000000297647c698c0b478")
             .is_ok()); // 2.987654321098765432
-        assert_eq!(context.get_result().unwrap(), "4.11111111011111111"); // 1.123456789012345678 + 2.987654321098765432
+        let result_hex = context.get_result().unwrap();
+        let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
+        assert_eq!(result_decimal, "4.11111111011111111"); // 1.123456789012345678 + 2.987654321098765432
 
         assert!(context
             .add_value("0x0000000000000000000000000000000000000000000000000000000000000064")
             .is_ok()); // 100
-        assert_eq!(context.get_result().unwrap(), "104.11111111011111111"); // 4.11111111011111111 + 100
+        let result_hex = context.get_result().unwrap();
+        let result_decimal = Float::from_hex(&result_hex).unwrap().format().unwrap();
+        assert_eq!(result_decimal, "104.11111111011111111"); // 4.11111111011111111 + 100
     }
 }

--- a/packages/sqlite-web-core/src/database_functions/mod.rs
+++ b/packages/sqlite-web-core/src/database_functions/mod.rs
@@ -8,10 +8,13 @@ use std::str::FromStr;
 
 // Import the individual function modules
 mod bigint_sum;
+mod float_sum;
 mod rain_math;
+
 
 // Re-export the functions
 pub use bigint_sum::*;
+pub use float_sum::*;
 pub use rain_math::*;
 
 /// Register all custom functions with the SQLite database
@@ -54,6 +57,26 @@ pub fn register_custom_functions(db: *mut sqlite3) -> Result<(), String> {
 
     if ret != SQLITE_OK {
         return Err("Failed to register BIGINT_SUM function".to_string());
+    }
+
+    // Register FLOAT_SUM aggregate function
+    let float_sum_name = CString::new("FLOAT_SUM").unwrap();
+    let ret = unsafe {
+        sqlite3_create_function_v2(
+            db,
+            float_sum_name.as_ptr(),
+            1, // 1 argument
+            SQLITE_UTF8,
+            std::ptr::null_mut(),
+            None,                  // No xFunc for aggregate function
+            Some(float_sum_step),  // xStep callback
+            Some(float_sum_final), // xFinal callback
+            None,                  // No destructor
+        )
+    };
+
+    if ret != SQLITE_OK {
+        return Err("Failed to register FLOAT_SUM function".to_string());
     }
 
     Ok(())

--- a/packages/sqlite-web-core/src/database_functions/mod.rs
+++ b/packages/sqlite-web-core/src/database_functions/mod.rs
@@ -11,7 +11,6 @@ mod bigint_sum;
 mod float_sum;
 mod rain_math;
 
-
 // Re-export the functions
 pub use bigint_sum::*;
 pub use float_sum::*;

--- a/svelte-test/package-lock.json
+++ b/svelte-test/package-lock.json
@@ -4076,7 +4076,7 @@
 		"node_modules/sqlite-web": {
 			"version": "0.1.0",
 			"resolved": "file:../pkg/sqlite-web-0.1.0.tgz",
-			"integrity": "sha512-stlOMIxQGUIo/EOGVPdvZziIpoUyzBkbjZqRhMXk26rKMfE5j8xHzWSYhXOAWrKM/CNpPca+ZqAbxeTQpoqwWA=="
+			"integrity": "sha512-Mt7zBN1IZHnC8ofu817lOTbekrsRuh8VKXgm3OMdtppbBHNnhGiHNC/ukI902D0zgI2EZbWweAHkp/iO3K2uKg=="
 		},
 		"node_modules/stackback": {
 			"version": "0.0.2",

--- a/svelte-test/package-lock.json
+++ b/svelte-test/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "svelte-test",
 			"version": "0.0.1",
 			"dependencies": {
+				"@rainlanguage/float": "^0.0.0-alpha.22",
 				"sqlite-web": "file:../pkg/sqlite-web-0.1.0.tgz"
 			},
 			"devDependencies": {
@@ -96,17 +97,6 @@
 			"license": "ISC",
 			"dependencies": {
 				"statuses": "^2.0.1"
-			}
-		},
-		"node_modules/@bundled-es-modules/tough-cookie": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/@bundled-es-modules/tough-cookie/-/tough-cookie-0.1.6.tgz",
-			"integrity": "sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@types/tough-cookie": "^4.0.5",
-				"tough-cookie": "^4.1.4"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -552,9 +542,9 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-			"integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.8.0.tgz",
+			"integrity": "sha512-MJQFqrZgcW0UNYLGOuQpey/oTN59vyWwplvCGZztn1cKz9agZPPYpJB7h2OMmuu7VLqkvEjN8feFZJmxNF9D+Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -929,10 +919,22 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@rainlanguage/float": {
+			"version": "0.0.0-alpha.22",
+			"resolved": "https://registry.npmjs.org/@rainlanguage/float/-/float-0.0.0-alpha.22.tgz",
+			"integrity": "sha512-j0+HBN/DhDGA6R4FuAi+xUkmZu4B61gTzMS6QXFc3Y5XPEiYwl6CRscP3BLnZovDaHIQ8ePXHVntWoETSJvz6w==",
+			"license": "LicenseRef-DCL-1.0",
+			"dependencies": {
+				"buffer": "6.0.3"
+			},
+			"engines": {
+				"node": ">=22"
+			}
+		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.48.1.tgz",
-			"integrity": "sha512-rGmb8qoG/zdmKoYELCBwu7vt+9HxZ7Koos3pD0+sH5fR3u3Wb/jGcpnqxcnWsPEKDUyzeLSqksN8LJtgXjqBYw==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.0.tgz",
+			"integrity": "sha512-lVgpeQyy4fWN5QYebtW4buT/4kn4p4IJ+kDNB4uYNT5b8c8DLJDg6titg20NIg7E8RWwdWZORW6vUFfrLyG3KQ==",
 			"cpu": [
 				"arm"
 			],
@@ -944,9 +946,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.48.1.tgz",
-			"integrity": "sha512-4e9WtTxrk3gu1DFE+imNJr4WsL13nWbD/Y6wQcyku5qadlKHY3OQ3LJ/INrrjngv2BJIHnIzbqMk1GTAC2P8yQ==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.0.tgz",
+			"integrity": "sha512-2O73dR4Dc9bp+wSYhviP6sDziurB5/HCym7xILKifWdE9UsOe2FtNcM+I4xZjKrfLJnq5UR8k9riB87gauiQtw==",
 			"cpu": [
 				"arm64"
 			],
@@ -958,9 +960,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.48.1.tgz",
-			"integrity": "sha512-+XjmyChHfc4TSs6WUQGmVf7Hkg8ferMAE2aNYYWjiLzAS/T62uOsdfnqv+GHRjq7rKRnYh4mwWb4Hz7h/alp8A==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.0.tgz",
+			"integrity": "sha512-vwSXQN8T4sKf1RHr1F0s98Pf8UPz7pS6P3LG9NSmuw0TVh7EmaE+5Ny7hJOZ0M2yuTctEsHHRTMi2wuHkdS6Hg==",
 			"cpu": [
 				"arm64"
 			],
@@ -972,9 +974,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.48.1.tgz",
-			"integrity": "sha512-upGEY7Ftw8M6BAJyGwnwMw91rSqXTcOKZnnveKrVWsMTF8/k5mleKSuh7D4v4IV1pLxKAk3Tbs0Lo9qYmii5mQ==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.0.tgz",
+			"integrity": "sha512-cQp/WG8HE7BCGyFVuzUg0FNmupxC+EPZEwWu2FCGGw5WDT1o2/YlENbm5e9SMvfDFR6FRhVCBePLqj0o8MN7Vw==",
 			"cpu": [
 				"x64"
 			],
@@ -986,9 +988,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.48.1.tgz",
-			"integrity": "sha512-P9ViWakdoynYFUOZhqq97vBrhuvRLAbN/p2tAVJvhLb8SvN7rbBnJQcBu8e/rQts42pXGLVhfsAP0k9KXWa3nQ==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.0.tgz",
+			"integrity": "sha512-UR1uTJFU/p801DvvBbtDD7z9mQL8J80xB0bR7DqW7UGQHRm/OaKzp4is7sQSdbt2pjjSS72eAtRh43hNduTnnQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1000,9 +1002,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.48.1.tgz",
-			"integrity": "sha512-VLKIwIpnBya5/saccM8JshpbxfyJt0Dsli0PjXozHwbSVaHTvWXJH1bbCwPXxnMzU4zVEfgD1HpW3VQHomi2AQ==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.0.tgz",
+			"integrity": "sha512-G/DKyS6PK0dD0+VEzH/6n/hWDNPDZSMBmqsElWnCRGrYOb2jC0VSupp7UAHHQ4+QILwkxSMaYIbQ72dktp8pKA==",
 			"cpu": [
 				"x64"
 			],
@@ -1014,9 +1016,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.48.1.tgz",
-			"integrity": "sha512-3zEuZsXfKaw8n/yF7t8N6NNdhyFw3s8xJTqjbTDXlipwrEHo4GtIKcMJr5Ed29leLpB9AugtAQpAHW0jvtKKaQ==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.0.tgz",
+			"integrity": "sha512-u72Mzc6jyJwKjJbZZcIYmd9bumJu7KNmHYdue43vT1rXPm2rITwmPWF0mmPzLm9/vJWxIRbao/jrQmxTO0Sm9w==",
 			"cpu": [
 				"arm"
 			],
@@ -1028,9 +1030,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.48.1.tgz",
-			"integrity": "sha512-leo9tOIlKrcBmmEypzunV/2w946JeLbTdDlwEZ7OnnsUyelZ72NMnT4B2vsikSgwQifjnJUbdXzuW4ToN1wV+Q==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.0.tgz",
+			"integrity": "sha512-S4UefYdV0tnynDJV1mdkNawp0E5Qm2MtSs330IyHgaccOFrwqsvgigUD29uT+B/70PDY1eQ3t40+xf6wIvXJyg==",
 			"cpu": [
 				"arm"
 			],
@@ -1042,9 +1044,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.48.1.tgz",
-			"integrity": "sha512-Vy/WS4z4jEyvnJm+CnPfExIv5sSKqZrUr98h03hpAMbE2aI0aD2wvK6GiSe8Gx2wGp3eD81cYDpLLBqNb2ydwQ==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.0.tgz",
+			"integrity": "sha512-1EhkSvUQXJsIhk4msxP5nNAUWoB4MFDHhtc4gAYvnqoHlaL9V3F37pNHabndawsfy/Tp7BPiy/aSa6XBYbaD1g==",
 			"cpu": [
 				"arm64"
 			],
@@ -1056,9 +1058,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.48.1.tgz",
-			"integrity": "sha512-x5Kzn7XTwIssU9UYqWDB9VpLpfHYuXw5c6bJr4Mzv9kIv242vmJHbI5PJJEnmBYitUIfoMCODDhR7KoZLot2VQ==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.0.tgz",
+			"integrity": "sha512-EtBDIZuDtVg75xIPIK1l5vCXNNCIRM0OBPUG+tbApDuJAy9mKago6QxX+tfMzbCI6tXEhMuZuN1+CU8iDW+0UQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1070,9 +1072,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.48.1.tgz",
-			"integrity": "sha512-yzCaBbwkkWt/EcgJOKDUdUpMHjhiZT/eDktOPWvSRpqrVE04p0Nd6EGV4/g7MARXXeOqstflqsKuXVM3H9wOIQ==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.50.0.tgz",
+			"integrity": "sha512-BGYSwJdMP0hT5CCmljuSNx7+k+0upweM2M4YGfFBjnFSZMHOLYR0gEEj/dxyYJ6Zc6AiSeaBY8dWOa11GF/ppQ==",
 			"cpu": [
 				"loong64"
 			],
@@ -1084,9 +1086,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.48.1.tgz",
-			"integrity": "sha512-UK0WzWUjMAJccHIeOpPhPcKBqax7QFg47hwZTp6kiMhQHeOYJeaMwzeRZe1q5IiTKsaLnHu9s6toSYVUlZ2QtQ==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.0.tgz",
+			"integrity": "sha512-I1gSMzkVe1KzAxKAroCJL30hA4DqSi+wGc5gviD0y3IL/VkvcnAqwBf4RHXHyvH66YVHxpKO8ojrgc4SrWAnLg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1098,9 +1100,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.48.1.tgz",
-			"integrity": "sha512-3NADEIlt+aCdCbWVZ7D3tBjBX1lHpXxcvrLt/kdXTiBrOds8APTdtk2yRL2GgmnSVeX4YS1JIf0imFujg78vpw==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.0.tgz",
+			"integrity": "sha512-bSbWlY3jZo7molh4tc5dKfeSxkqnf48UsLqYbUhnkdnfgZjgufLS/NTA8PcP/dnvct5CCdNkABJ56CbclMRYCA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1112,9 +1114,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.48.1.tgz",
-			"integrity": "sha512-euuwm/QTXAMOcyiFCcrx0/S2jGvFlKJ2Iro8rsmYL53dlblp3LkUQVFzEidHhvIPPvcIsxDhl2wkBE+I6YVGzA==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.0.tgz",
+			"integrity": "sha512-LSXSGumSURzEQLT2e4sFqFOv3LWZsEF8FK7AAv9zHZNDdMnUPYH3t8ZlaeYYZyTXnsob3htwTKeWtBIkPV27iQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1126,9 +1128,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.48.1.tgz",
-			"integrity": "sha512-w8mULUjmPdWLJgmTYJx/W6Qhln1a+yqvgwmGXcQl2vFBkWsKGUBRbtLRuKJUln8Uaimf07zgJNxOhHOvjSQmBQ==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.0.tgz",
+			"integrity": "sha512-CxRKyakfDrsLXiCyucVfVWVoaPA4oFSpPpDwlMcDFQvrv3XY6KEzMtMZrA+e/goC8xxp2WSOxHQubP8fPmmjOQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -1140,9 +1142,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.48.1.tgz",
-			"integrity": "sha512-90taWXCWxTbClWuMZD0DKYohY1EovA+W5iytpE89oUPmT5O1HFdf8cuuVIylE6vCbrGdIGv85lVRzTcpTRZ+kA==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.0.tgz",
+			"integrity": "sha512-8PrJJA7/VU8ToHVEPu14FzuSAqVKyo5gg/J8xUerMbyNkWkO9j2ExBho/68RnJsMGNJq4zH114iAttgm7BZVkA==",
 			"cpu": [
 				"x64"
 			],
@@ -1154,9 +1156,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.48.1.tgz",
-			"integrity": "sha512-2Gu29SkFh1FfTRuN1GR1afMuND2GKzlORQUP3mNMJbqdndOg7gNsa81JnORctazHRokiDzQ5+MLE5XYmZW5VWg==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.0.tgz",
+			"integrity": "sha512-SkE6YQp+CzpyOrbw7Oc4MgXFvTw2UIBElvAvLCo230pyxOLmYwRPwZ/L5lBe/VW/qT1ZgND9wJfOsdy0XptRvw==",
 			"cpu": [
 				"x64"
 			],
@@ -1167,10 +1169,24 @@
 				"linux"
 			]
 		},
+		"node_modules/@rollup/rollup-openharmony-arm64": {
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.0.tgz",
+			"integrity": "sha512-PZkNLPfvXeIOgJWA804zjSFH7fARBBCpCXxgkGDRjjAhRLOR8o0IGS01ykh5GYfod4c2yiiREuDM8iZ+pVsT+Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.48.1.tgz",
-			"integrity": "sha512-6kQFR1WuAO50bxkIlAVeIYsz3RUx+xymwhTo9j94dJ+kmHe9ly7muH23sdfWduD0BA8pD9/yhonUvAjxGh34jQ==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.0.tgz",
+			"integrity": "sha512-q7cIIdFvWQoaCbLDUyUc8YfR3Jh2xx3unO8Dn6/TTogKjfwrax9SyfmGGK6cQhKtjePI7jRfd7iRYcxYs93esg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1182,9 +1198,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.48.1.tgz",
-			"integrity": "sha512-RUyZZ/mga88lMI3RlXFs4WQ7n3VyU07sPXmMG7/C1NOi8qisUg57Y7LRarqoGoAiopmGmChUhSwfpvQ3H5iGSQ==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.0.tgz",
+			"integrity": "sha512-XzNOVg/YnDOmFdDKcxxK410PrcbcqZkBmz+0FicpW5jtjKQxcW1BZJEQOF0NJa6JO7CZhett8GEtRN/wYLYJuw==",
 			"cpu": [
 				"ia32"
 			],
@@ -1196,9 +1212,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.48.1.tgz",
-			"integrity": "sha512-8a/caCUN4vkTChxkaIJcMtwIVcBhi4X2PQRoT+yCK3qRYaZ7cURrmJFL5Ux9H9RaMIXj9RuihckdmkBX3zZsgg==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.0.tgz",
+			"integrity": "sha512-xMmiWRR8sp72Zqwjgtf3QbZfF1wdh8X2ABu3EaozvZcyHJeU0r+XAnXdKgs4cCAp6ORoYoCygipYP1mjmbjrsg==",
 			"cpu": [
 				"x64"
 			],
@@ -1237,9 +1253,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.36.3",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.36.3.tgz",
-			"integrity": "sha512-MVzwZz1GFznEQbL3f0i2v9AIc3lZH01izQj6XfIrthmZAwOzyXJCgXbLRss8vk//HfYsE4w6Tz+ukbf3rScPNQ==",
+			"version": "2.37.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.37.0.tgz",
+			"integrity": "sha512-xgKtpjQ6Ry4mdShd01ht5AODUsW7+K1iValPDq7QX8zI1hWOKREH9GjG8SRCN5tC4K7UXmMhuQam7gbLByVcnw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1276,16 +1292,15 @@
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "6.1.3",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-6.1.3.tgz",
-			"integrity": "sha512-3pppgIeIZs6nrQLazzKcdnTJ2IWiui/UucEPXKyFG35TKaHQrfkWBnv6hyJcLxFuR90t+LaoecrqTs8rJKWfSQ==",
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-6.1.4.tgz",
+			"integrity": "sha512-4jfkfvsGI+U2OhHX8OPCKtMCf7g7ledXhs3E6UcA4EY0jQWsiVbe83pTAHp9XTifzYNOiD4AJieJUsI0qqxsbw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
 				"debug": "^4.4.1",
 				"deepmerge": "^4.3.1",
-				"kleur": "^4.1.5",
 				"magic-string": "^0.30.17",
 				"vitefu": "^1.1.1"
 			},
@@ -1389,9 +1404,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "24.3.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-			"integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+			"version": "24.3.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+			"integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1402,13 +1417,6 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
 			"integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@types/tough-cookie": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
-			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1933,6 +1941,26 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/brace-expansion": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -1954,6 +1982,30 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
 			}
 		},
 		"node_modules/cac": {
@@ -2937,6 +2989,26 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3287,16 +3359,15 @@
 			"license": "MIT"
 		},
 		"node_modules/msw": {
-			"version": "2.10.5",
-			"resolved": "https://registry.npmjs.org/msw/-/msw-2.10.5.tgz",
-			"integrity": "sha512-0EsQCrCI1HbhpBWd89DvmxY6plmvrM96b0sCIztnvcNHQbXn5vqwm1KlXslo6u4wN9LFGLC1WFjjgljcQhe40A==",
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/msw/-/msw-2.11.1.tgz",
+			"integrity": "sha512-dGSRx0AJmQVQfpGXTsAAq4JFdwdhOBdJ6sJS/jnN0ac3s0NZB6daacHF1z5Pefx+IejmvuiLWw260RlyQOf3sQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bundled-es-modules/cookie": "^2.0.1",
 				"@bundled-es-modules/statuses": "^1.0.1",
-				"@bundled-es-modules/tough-cookie": "^0.1.6",
 				"@inquirer/confirm": "^5.0.0",
 				"@mswjs/interceptors": "^0.39.1",
 				"@open-draft/deferred-promise": "^2.2.0",
@@ -3310,6 +3381,7 @@
 				"path-to-regexp": "^6.3.0",
 				"picocolors": "^1.1.1",
 				"strict-event-emitter": "^0.5.1",
+				"tough-cookie": "^6.0.0",
 				"type-fest": "^4.26.1",
 				"yargs": "^17.7.2"
 			},
@@ -3771,19 +3843,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/psl": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-			"integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"punycode": "^2.3.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/lupomontero"
-			}
-		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3793,13 +3852,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/querystringify": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
@@ -3853,13 +3905,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/requires-port": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3899,9 +3944,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.48.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.48.1.tgz",
-			"integrity": "sha512-jVG20NvbhTYDkGAty2/Yh7HK6/q3DGSRH4o8ALKGArmMuaauM9kLfoMZ+WliPwA5+JHr2lTn3g557FxBV87ifg==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.0.tgz",
+			"integrity": "sha512-/Zl4D8zPifNmyGzJS+3kVoyXeDeT/GrsJM94sACNg9RtUE0hrHa1bNPtRSrfHTMH5HjRzce6K7rlTh3Khiw+pw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3915,26 +3960,27 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.48.1",
-				"@rollup/rollup-android-arm64": "4.48.1",
-				"@rollup/rollup-darwin-arm64": "4.48.1",
-				"@rollup/rollup-darwin-x64": "4.48.1",
-				"@rollup/rollup-freebsd-arm64": "4.48.1",
-				"@rollup/rollup-freebsd-x64": "4.48.1",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.48.1",
-				"@rollup/rollup-linux-arm-musleabihf": "4.48.1",
-				"@rollup/rollup-linux-arm64-gnu": "4.48.1",
-				"@rollup/rollup-linux-arm64-musl": "4.48.1",
-				"@rollup/rollup-linux-loongarch64-gnu": "4.48.1",
-				"@rollup/rollup-linux-ppc64-gnu": "4.48.1",
-				"@rollup/rollup-linux-riscv64-gnu": "4.48.1",
-				"@rollup/rollup-linux-riscv64-musl": "4.48.1",
-				"@rollup/rollup-linux-s390x-gnu": "4.48.1",
-				"@rollup/rollup-linux-x64-gnu": "4.48.1",
-				"@rollup/rollup-linux-x64-musl": "4.48.1",
-				"@rollup/rollup-win32-arm64-msvc": "4.48.1",
-				"@rollup/rollup-win32-ia32-msvc": "4.48.1",
-				"@rollup/rollup-win32-x64-msvc": "4.48.1",
+				"@rollup/rollup-android-arm-eabi": "4.50.0",
+				"@rollup/rollup-android-arm64": "4.50.0",
+				"@rollup/rollup-darwin-arm64": "4.50.0",
+				"@rollup/rollup-darwin-x64": "4.50.0",
+				"@rollup/rollup-freebsd-arm64": "4.50.0",
+				"@rollup/rollup-freebsd-x64": "4.50.0",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.50.0",
+				"@rollup/rollup-linux-arm-musleabihf": "4.50.0",
+				"@rollup/rollup-linux-arm64-gnu": "4.50.0",
+				"@rollup/rollup-linux-arm64-musl": "4.50.0",
+				"@rollup/rollup-linux-loongarch64-gnu": "4.50.0",
+				"@rollup/rollup-linux-ppc64-gnu": "4.50.0",
+				"@rollup/rollup-linux-riscv64-gnu": "4.50.0",
+				"@rollup/rollup-linux-riscv64-musl": "4.50.0",
+				"@rollup/rollup-linux-s390x-gnu": "4.50.0",
+				"@rollup/rollup-linux-x64-gnu": "4.50.0",
+				"@rollup/rollup-linux-x64-musl": "4.50.0",
+				"@rollup/rollup-openharmony-arm64": "4.50.0",
+				"@rollup/rollup-win32-arm64-msvc": "4.50.0",
+				"@rollup/rollup-win32-ia32-msvc": "4.50.0",
+				"@rollup/rollup-win32-x64-msvc": "4.50.0",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -4039,9 +4085,9 @@
 			}
 		},
 		"node_modules/sirv": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.1.tgz",
-			"integrity": "sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+			"integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4076,7 +4122,7 @@
 		"node_modules/sqlite-web": {
 			"version": "0.1.0",
 			"resolved": "file:../pkg/sqlite-web-0.1.0.tgz",
-			"integrity": "sha512-Mt7zBN1IZHnC8ofu817lOTbekrsRuh8VKXgm3OMdtppbBHNnhGiHNC/ukI902D0zgI2EZbWweAHkp/iO3K2uKg=="
+			"integrity": "sha512-vZrEmy4lBLoce7i8MvSX/a04ohgySbR+wz3SkjzBWc+AfYZKeSWH2x3SqDOlfwG+X4tpzSQc2HgiGJXgKTuRBA=="
 		},
 		"node_modules/stackback": {
 			"version": "0.0.2",
@@ -4164,9 +4210,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.38.5",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.38.5.tgz",
-			"integrity": "sha512-4Go68OcH6VL4plTJMxry8ZQFxnZ8pu2EA5nNPxNHOUgCd/0lo00JZh8wnAQ2mdEK09GSYuumG+14Egk7thd6Lw==",
+			"version": "5.38.6",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.38.6.tgz",
+			"integrity": "sha512-ltBPlkvqk3bgCK7/N323atUpP3O3Y+DrGV4dcULrsSn4fZaaNnOmdplNznwfdWclAgvSr5rxjtzn/zJhRm6TKg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4385,6 +4431,26 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/tldts": {
+			"version": "7.0.12",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.12.tgz",
+			"integrity": "sha512-M9ZQBPp6FyqhMcl233vHYyYRkxXOA1SKGlnq13S0mJdUhRSwr2w6I8rlchPL73wBwRlyIZpFvpu2VcdSMWLYXw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^7.0.12"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "7.0.12",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.12.tgz",
+			"integrity": "sha512-3K76aXywJFduGRsOYoY5JzINLs/WMlOkeDwPL+8OCPq2Rh39gkSDtWAxdJQlWjpun/xF/LHf29yqCi6VC/rHDA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4409,19 +4475,16 @@
 			}
 		},
 		"node_modules/tough-cookie": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-			"integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+			"integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"psl": "^1.1.33",
-				"punycode": "^2.1.1",
-				"universalify": "^0.2.0",
-				"url-parse": "^1.5.3"
+				"tldts": "^7.0.5"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=16"
 			}
 		},
 		"node_modules/ts-api-utils": {
@@ -4705,16 +4768,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/universalify": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4.0.0"
-			}
-		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4725,17 +4778,6 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"node_modules/url-parse": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"querystringify": "^2.1.1",
-				"requires-port": "^1.0.0"
-			}
-		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -4744,9 +4786,9 @@
 			"license": "MIT"
 		},
 		"node_modules/vite": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.1.3.tgz",
-			"integrity": "sha512-OOUi5zjkDxYrKhTV3V7iKsoS37VUM7v40+HuwEmcrsf11Cdx9y3DIr2Px6liIcZFwt3XSRpQvFpL3WVy7ApkGw==",
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.1.4.tgz",
+			"integrity": "sha512-X5QFK4SGynAeeIt+A7ZWnApdUyHYm+pzv/8/A57LqSGcI88U6R6ipOs3uCesdc6yl7nl+zNO0t8LmqAdXcQihw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/svelte-test/package-lock.json
+++ b/svelte-test/package-lock.json
@@ -1657,6 +1657,420 @@
 				}
 			}
 		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/aix-ppc64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+			"integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/android-arm": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+			"integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/android-arm64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+			"integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/android-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+			"integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+			"integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/darwin-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+			"integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+			"integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+			"integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/linux-arm": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+			"integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/linux-arm64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+			"integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/linux-ia32": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+			"integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/linux-loong64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+			"integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+			"integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+			"integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/linux-riscv64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+			"integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/linux-s390x": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+			"integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/linux-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+			"integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+			"integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+			"integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/sunos-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+			"integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/win32-arm64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+			"integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/win32-ia32": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+			"integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/@esbuild/win32-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+			"integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@vitest/browser/node_modules/@vitest/mocker": {
 			"version": "2.1.9",
 			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
@@ -1680,6 +2094,125 @@
 					"optional": true
 				},
 				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/esbuild": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+			"integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.21.5",
+				"@esbuild/android-arm": "0.21.5",
+				"@esbuild/android-arm64": "0.21.5",
+				"@esbuild/android-x64": "0.21.5",
+				"@esbuild/darwin-arm64": "0.21.5",
+				"@esbuild/darwin-x64": "0.21.5",
+				"@esbuild/freebsd-arm64": "0.21.5",
+				"@esbuild/freebsd-x64": "0.21.5",
+				"@esbuild/linux-arm": "0.21.5",
+				"@esbuild/linux-arm64": "0.21.5",
+				"@esbuild/linux-ia32": "0.21.5",
+				"@esbuild/linux-loong64": "0.21.5",
+				"@esbuild/linux-mips64el": "0.21.5",
+				"@esbuild/linux-ppc64": "0.21.5",
+				"@esbuild/linux-riscv64": "0.21.5",
+				"@esbuild/linux-s390x": "0.21.5",
+				"@esbuild/linux-x64": "0.21.5",
+				"@esbuild/netbsd-x64": "0.21.5",
+				"@esbuild/openbsd-x64": "0.21.5",
+				"@esbuild/sunos-x64": "0.21.5",
+				"@esbuild/win32-arm64": "0.21.5",
+				"@esbuild/win32-ia32": "0.21.5",
+				"@esbuild/win32-x64": "0.21.5"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/@vitest/browser/node_modules/vite": {
+			"version": "5.4.19",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
+			"integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"esbuild": "^0.21.3",
+				"postcss": "^8.4.43",
+				"rollup": "^4.20.0"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^18.0.0 || >=20.0.0",
+				"less": "*",
+				"lightningcss": "^1.21.0",
+				"sass": "*",
+				"sass-embedded": "*",
+				"stylus": "*",
+				"sugarss": "*",
+				"terser": "^5.4.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
 					"optional": true
 				}
 			}
@@ -4275,6 +4808,21 @@
 				"picomatch": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/svelte-check/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/svelte-eslint-parser": {

--- a/svelte-test/package.json
+++ b/svelte-test/package.json
@@ -40,6 +40,7 @@
 	},
 	"type": "module",
 	"dependencies": {
+		"@rainlanguage/float": "^0.0.0-alpha.22",
 		"sqlite-web": "file:../pkg/sqlite-web-0.1.0.tgz"
 	}
 }

--- a/svelte-test/tests/database-functions/float-sum.test.ts
+++ b/svelte-test/tests/database-functions/float-sum.test.ts
@@ -324,6 +324,31 @@ describe("FLOAT_SUM Database Function", () => {
       expect(result.error?.msg).toContain("Failed to parse hex number");
     });
 
+    it("should sum signed float values correctly", async () => {
+      await db.query("DELETE FROM float_test");
+
+      const negative = encodeFloatHex("-2.5");
+      const positive = encodeFloatHex("3.1");
+
+      await db.query(`
+				INSERT INTO float_test (amount) VALUES
+				('${negative}'),
+				('${positive}')
+			`);
+
+      const result = await db.query(
+        "SELECT FLOAT_SUM(amount) as total FROM float_test",
+      );
+      expect(result.error).toBeUndefined();
+
+      const data = JSON.parse(result.value || "[]") as Array<{ total: string }>;
+      expect(Array.isArray(data)).toBe(true);
+      expect(data).toHaveLength(1);
+
+      const decodedTotal = decodeFloatHex(data[0].total);
+      expect(decodedTotal).toBe("0.6");
+    });
+
     it("should handle only valid hex values", async () => {
       await db.query(`
 				INSERT INTO float_test (amount) VALUES

--- a/svelte-test/tests/database-functions/float-sum.test.ts
+++ b/svelte-test/tests/database-functions/float-sum.test.ts
@@ -1,0 +1,482 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { 
+	createTestDatabase, 
+	cleanupDatabase, 
+	assertions,
+	PerformanceTracker 
+} from '../fixtures/test-helpers.js';
+import type { SQLiteWasmDatabase } from 'sqlite-web';
+
+interface CategoryRow {
+	category: string;
+	total: string;
+}
+
+interface TransactionRow {
+	category: string;
+	total_float: string;
+}
+
+describe('FLOAT_SUM Database Function', () => {
+	let db: SQLiteWasmDatabase;
+	let perf: PerformanceTracker;
+	
+	beforeEach(async () => {
+		db = await createTestDatabase();
+		perf = new PerformanceTracker();
+		
+		await db.query(`
+			CREATE TABLE float_test (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				amount TEXT NOT NULL,
+				category TEXT,
+				description TEXT
+			)
+		`);
+	});
+	
+	afterEach(async () => {
+		await cleanupDatabase(db);
+	});
+
+	describe('Function Availability', () => {
+		it('should have FLOAT_SUM function available', async () => {
+			try {
+				const pragmaResult = await db.query('PRAGMA function_list');
+				expect(pragmaResult).toBeDefined();
+				const functions = JSON.parse(pragmaResult.value || '[]');
+				const floatSumEntry = functions.find((f: any) => f.name === 'FLOAT_SUM');
+				expect(floatSumEntry).toBeDefined();
+			} catch (error) {
+			}
+
+			try {
+				const rainResult = await db.query('SELECT RAIN_MATH_PROCESS("100", "200") as test');
+				expect(rainResult).toBeDefined();
+				expect(rainResult.value).toBeDefined();
+			} catch (error) {
+				throw new Error('RAIN_MATH_PROCESS not available');
+			}
+
+			try {
+				const result = await db.query('SELECT FLOAT_SUM("0xffffffff00000000000000000000000000000000000000000000000000000001") as test');
+				expect(result).toBeDefined();
+				expect(result.value).toBeDefined();
+				const data = JSON.parse(result.value || '[]');
+				expect(data[0].test).toBe('0.1');
+			} catch (error) {
+				throw new Error('FLOAT_SUM function not available');
+			}
+		});
+	});
+
+	describe('Basic FLOAT_SUM Functionality', () => {
+		beforeEach(async () => {
+			await db.query(`
+				INSERT INTO float_test (amount, category, description) VALUES 
+				('0xffffffff00000000000000000000000000000000000000000000000000000001', 'income', 'payment'),
+				('0xffffffff00000000000000000000000000000000000000000000000000000005', 'income', 'deposit'),
+				('ffffffff0000000000000000000000000000000000000000000000000000000f', 'income', 'amount')
+			`);
+		});
+
+		it('should sum positive float values correctly', async () => {
+			perf.start('float-sum-positive');
+			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
+			perf.end('float-sum-positive');
+			
+			const data = JSON.parse(result.value || '[]');
+			
+			expect(data).toHaveLength(1);
+			expect(data[0]).toHaveProperty('total');
+			
+			expect(data[0].total).toBe('2.1');
+			expect(perf.getDuration('float-sum-positive')).toBeLessThan(1000);
+		});
+
+		it('should handle single row correctly', async () => {
+			await db.query('DELETE FROM float_test WHERE id > 1');
+			
+			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
+			const data = JSON.parse(result.value || '[]');
+			
+			expect(data[0].total).toBe('0.1');
+		});
+
+		it('should return 0 for empty table', async () => {
+			await db.query('DELETE FROM float_test');
+			
+			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
+			const data = JSON.parse(result.value || '[]');
+			
+			expect(data[0].total).toBe('0');
+		});
+	});
+
+	describe('Hex Format Support', () => {
+		beforeEach(async () => {
+			await db.query(`
+				INSERT INTO float_test (amount, category, description) VALUES 
+				('0xfffffffe00000000000000000000000000000000000000000000000000002729', 'income', 'large payment'),
+				('fffffffd0000000000000000000000000000000000000000000000000001e240', 'income', 'large deposit'),
+				('0x0000000000000000000000000000000000000000000000000000000000000000', 'zero', 'zero value')
+			`);
+		});
+
+		it('should handle hex values with and without 0x prefix', async () => {
+			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
+			const data = JSON.parse(result.value || '[]');
+			
+			expect(data[0].total).toBe('223.706');
+		});
+
+		it('should handle mixed case hex values', async () => {
+			await db.query('DELETE FROM float_test');
+			await db.query(`
+				INSERT INTO float_test (amount) VALUES 
+				('0xFfFfFfFf0000000000000000000000000000000000000000000000000000000F'),
+				('0xFfFfFfFe000000000000000000000000000000000000000000000000000000E1')
+			`);
+			
+			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
+			const data = JSON.parse(result.value || '[]');
+			
+			expect(data[0].total).toBe('3.75');
+		});
+
+		it('should reject uppercase 0X prefix', async () => {
+			await db.query('DELETE FROM float_test');
+			await db.query(`
+				INSERT INTO float_test (amount) VALUES ('0XFFFFFFFB0000000000000000000000000000000000000000000000000004CB2F')
+			`);
+			
+			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
+			expect(result.error).toBeDefined();
+			expect(result.error?.msg).toContain('Failed to parse hex number');
+		});
+	});
+
+	describe('GROUP BY Operations', () => {
+		beforeEach(async () => {
+			await db.query(`
+				INSERT INTO float_test (amount, category) VALUES 
+				('0xffffffff00000000000000000000000000000000000000000000000000000001', 'income'),
+				('0xffffffff00000000000000000000000000000000000000000000000000000005', 'income'),
+				('0x000000000000000000000000000000000000000000000000000000000000000a', 'bonus'),
+				('ffffffff0000000000000000000000000000000000000000000000000000000f', 'expense')
+			`);
+		});
+
+		it('should work with GROUP BY clauses', async () => {
+			const result = await db.query(`
+				SELECT category, FLOAT_SUM(amount) as total 
+				FROM float_test 
+				GROUP BY category 
+				ORDER BY category
+			`);
+			const data = JSON.parse(result.value || '[]');
+			
+			expect(data).toHaveLength(3);
+			
+			const bonus = data.find((row: CategoryRow) => row.category === 'bonus');
+			const expense = data.find((row: CategoryRow) => row.category === 'expense');
+			const income = data.find((row: CategoryRow) => row.category === 'income');
+			
+			expect(bonus?.total).toBe('10');
+			expect(expense?.total).toBe('1.5');
+			expect(income?.total).toBe('0.6');
+		});
+
+		it('should work with HAVING clauses', async () => {
+			const result = await db.query(`
+				SELECT category, FLOAT_SUM(amount) as total 
+				FROM float_test 
+				GROUP BY category 
+				HAVING FLOAT_SUM(amount) > '1'
+				ORDER BY total DESC
+			`);
+			const data = JSON.parse(result.value || '[]');
+			
+			expect(data).toHaveLength(2);
+			const categories = data.map((row: CategoryRow) => row.category).sort();
+			expect(categories).toEqual(['bonus', 'expense']);
+		});
+	});
+
+	describe('Error Handling', () => {
+		it('should handle invalid hex strings gracefully', async () => {
+			await db.query(`
+				INSERT INTO float_test (amount) VALUES ('not_hex')
+			`);
+			
+			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
+			expect(result.error).toBeDefined();
+			expect(result.error?.msg).toContain('Failed to parse hex number');
+		});
+
+		it('should handle empty strings gracefully', async () => {
+			await db.query(`
+				INSERT INTO float_test (amount) VALUES ('')
+			`);
+			
+			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
+			expect(result.error).toBeDefined();
+			expect(result.error?.msg).toContain('Empty string is not a valid hex number');
+		});
+
+		it('should handle invalid hex characters', async () => {
+			await db.query(`
+				INSERT INTO float_test (amount) VALUES ('0xGHI')
+			`);
+			
+			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
+			expect(result.error).toBeDefined();
+			expect(result.error?.msg).toContain('Failed to parse hex number');
+		});
+
+		it('should handle only valid hex values', async () => {
+			await db.query(`
+				INSERT INTO float_test (amount) VALUES 
+				('0xffffffff00000000000000000000000000000000000000000000000000000001'),
+				('0xffffffff00000000000000000000000000000000000000000000000000000005')
+			`);
+			
+			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
+			const data = JSON.parse(result.value || '[]');
+			
+			expect(data[0].total).toBe('0.6');
+		});
+	});
+
+	describe('Edge Cases and Limits', () => {
+		it('should handle very small float values', async () => {
+			const smallValue = '0xffffffff00000000000000000000000000000000000000000000000000000001';
+			
+			await db.query(`
+				INSERT INTO float_test (amount) VALUES ('${smallValue}')
+			`);
+			
+			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
+			const data = JSON.parse(result.value || '[]');
+			
+			expect(data[0].total).toBe('0.1');
+		});
+
+		it('should reject hex values that are too short', async () => {
+			await db.query(`
+				INSERT INTO float_test (amount) VALUES ('0x0')
+			`);
+			
+			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
+			expect(result.error).toBeDefined();
+			expect(result.error?.msg).toContain('Failed to parse hex number');
+		});
+
+		it('should handle whitespace in hex values', async () => {
+			await db.query(`
+				INSERT INTO float_test (amount) VALUES 
+				('  0x000000000000000000000000000000000000000000000000000000000000000a  '),
+				('\t0x0000000000000000000000000000000000000000000000000000000000000014\n')
+			`);
+			
+			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
+			const data = JSON.parse(result.value || '[]');
+			
+			expect(data[0].total).toBe('30');
+		});
+	});
+
+	describe('High Precision Decimals', () => {
+		beforeEach(async () => {
+			await db.query(`
+				INSERT INTO float_test (amount, category, description) VALUES 
+				('0xffffffee0000000000000000000000000000000000000010450cb5d3cf60f34e', 'precision', 'high precision 1'),
+				('0xffffffee0000000000000000000000000000000000000010510af4e77328b478', 'precision', 'high precision 2'),
+				('0xffffffee00000000000000000000000000000000000000104b0bd55dbf1238e3', 'precision', 'high precision 3'),
+				('0xffffffee00000000000000000000000000000000000000104e21534cc7d31c71', 'precision', 'high precision 4'),
+				('0xffffffee00000000000000000000000000000000000000105136d13bd093ffff', 'precision', 'high precision 5')
+			`);
+		});
+
+		it('should handle high precision decimal calculations', async () => {
+			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
+			const data = JSON.parse(result.value || '[]');
+			
+			expect(data[0].total).toBe('1503.444444443444444441');
+		});
+
+		it('should handle mixed precision values correctly', async () => {
+			await db.query('DELETE FROM float_test');
+			await db.query(`
+				INSERT INTO float_test (amount) VALUES 
+				('0xffffffee00000000000000000000000000000000000000000f9751ff4d94f34e'),
+				('0xffffffee0000000000000000000000000000000000000000297647c698c0b478'),
+				('0x0000000000000000000000000000000000000000000000000000000000000064')
+			`);
+			
+			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
+			const data = JSON.parse(result.value || '[]');
+			
+			expect(data[0].total).toBe('104.11111111011111111');
+		});
+	});
+
+	describe('Performance Tests', () => {
+		it('should handle bulk aggregation efficiently', async () => {
+			const values = Array.from({ length: 10 }, (_, i) => 
+				`('0xffffffff00000000000000000000000000000000000000000000000000000001', 'bulk')`
+			).join(',');
+			
+			await db.query(`
+				INSERT INTO float_test (amount, category) VALUES ${values}
+			`);
+			
+			perf.start('bulk-float-sum');
+			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
+			perf.end('bulk-float-sum');
+			
+			if (result.error) {
+				throw new Error(`Query failed: ${result.error.msg}`);
+			}
+			
+			const data = JSON.parse(result.value || '[]');
+			expect(data).toHaveLength(1);
+			expect(data[0]).toHaveProperty('total');
+			expect(data[0].total).toBe('1');
+			expect(perf.getDuration('bulk-float-sum')).toBeLessThan(3000);
+		});
+
+		it('should handle complex queries with joins efficiently', async () => {
+			await db.query(`
+				CREATE TABLE float_categories (
+					name TEXT PRIMARY KEY,
+					multiplier TEXT
+				)
+			`);
+			
+			await db.query(`
+				INSERT INTO float_categories (name, multiplier) VALUES 
+				('income', '2'),
+				('expense', '1')
+			`);
+			
+			await db.query(`
+				INSERT INTO float_test (amount, category) VALUES 
+				('0xffffffff00000000000000000000000000000000000000000000000000000001', 'income'),
+				('0xffffffff00000000000000000000000000000000000000000000000000000005', 'expense')
+			`);
+			
+			perf.start('complex-float-query');
+			const result = await db.query(`
+				SELECT 
+					t.category,
+					FLOAT_SUM(t.amount) as total_amount,
+					c.multiplier
+				FROM float_test t
+				JOIN float_categories c ON t.category = c.name
+				GROUP BY t.category, c.multiplier
+				ORDER BY total_amount DESC
+			`);
+			perf.end('complex-float-query');
+			
+			const data = JSON.parse(result.value || '[]');
+			expect(Array.isArray(data)).toBe(true);
+			expect(data.length).toBe(2);
+			
+			const rowsByCategory = data.reduce((map: Record<string, any>, row: any) => {
+				map[row.category] = row;
+				return map;
+			}, {} as Record<string, any>);
+			
+			expect(rowsByCategory['income']).toBeDefined();
+			expect(rowsByCategory['income'].total_amount).toBe('0.1');
+			expect(rowsByCategory['income'].multiplier).toBe('2');
+			
+			expect(rowsByCategory['expense']).toBeDefined();
+			expect(rowsByCategory['expense'].total_amount).toBe('0.5');
+			expect(rowsByCategory['expense'].multiplier).toBe('1');
+			
+			expect(perf.getDuration('complex-float-query')).toBeLessThan(2000);
+		});
+	});
+
+	describe('Real-world Scenarios', () => {
+		it('should handle DeFi-like transaction amounts', async () => {
+			await db.query(`
+				INSERT INTO float_test (amount, category, description) VALUES 
+				('0xfffffffe00000000000000000000000000000000000000000000000000002729', 'swap', 'token swap'),
+				('0xfffffffd0000000000000000000000000000000000000000000000000001e240', 'liquidity', 'liquidity provision'),
+				('0xffffffff00000000000000000000000000000000000000000000000000000001', 'rewards', 'staking rewards'),
+				('0xffffffff00000000000000000000000000000000000000000000000000000005', 'fees', 'protocol fees')
+			`);
+			
+			const result = await db.query(`
+				SELECT 
+					category,
+					FLOAT_SUM(amount) as total_float,
+					COUNT(*) as transaction_count
+				FROM float_test 
+				GROUP BY category
+				ORDER BY total_float DESC
+			`);
+			
+			const data = JSON.parse(result.value || '[]');
+			expect(Array.isArray(data)).toBe(true);
+			
+			const liquidity = data.find((row: TransactionRow) => row.category === 'liquidity');
+			expect(liquidity?.total_float).toBe('123.456');
+		});
+
+		it('should handle precision accounting that must balance', async () => {
+			await db.query(`
+				INSERT INTO float_test (amount, description) VALUES 
+				('0xfffffffe00000000000000000000000000000000000000000000000000002729', 'Initial balance'),
+				('0xffffffff00000000000000000000000000000000000000000000000000000001', 'Small addition')
+			`);
+			
+			const result = await db.query('SELECT FLOAT_SUM(amount) as balance FROM float_test');
+			
+			if (result.error) {
+				throw new Error(`Query failed: ${result.error.msg}`);
+			}
+			
+			const data = JSON.parse(result.value || '[]');
+			expect(data).toHaveLength(1);
+			expect(data[0]).toHaveProperty('balance');
+			expect(data[0].balance).toBe('100.35');
+		});
+	});
+
+	describe('NULL Value Handling', () => {
+		it('should skip NULL values like standard SQL aggregates', async () => {
+			await db.query(`
+				INSERT INTO float_test (amount, category) VALUES 
+				('0xffffffff00000000000000000000000000000000000000000000000000000001', 'test'),
+				('0xffffffff00000000000000000000000000000000000000000000000000000005', 'test')
+			`);
+			
+			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
+			
+			if (result.error) {
+				throw new Error(`Query failed: ${result.error.msg}`);
+			}
+			
+			const data = JSON.parse(result.value || '[]');
+			expect(data).toHaveLength(1);
+			expect(data[0].total).toBe('0.6');
+		});
+
+		it('should return 0 when all values are NULL', async () => {
+			await db.query(`
+				INSERT INTO float_test (amount, category) VALUES 
+				(NULL, 'test'),
+				(NULL, 'test')
+			`);
+			
+			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
+			const data = JSON.parse(result.value || '[]');
+			
+			expect(data[0].total).toBe('0');
+		});
+	});
+});

--- a/svelte-test/tests/database-functions/float-sum.test.ts
+++ b/svelte-test/tests/database-functions/float-sum.test.ts
@@ -1,31 +1,44 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { 
-	createTestDatabase, 
-	cleanupDatabase, 
-	assertions,
-	PerformanceTracker 
-} from '../fixtures/test-helpers.js';
-import type { SQLiteWasmDatabase } from 'sqlite-web';
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  createTestDatabase,
+  cleanupDatabase,
+  assertions,
+  PerformanceTracker,
+} from "../fixtures/test-helpers.js";
+import type { SQLiteWasmDatabase } from "sqlite-web";
+import { Float } from "@rainlanguage/float";
 
 interface CategoryRow {
-	category: string;
-	total: string;
+  category: string;
+  total: string;
 }
 
 interface TransactionRow {
-	category: string;
-	total_float: string;
+  category: string;
+  total_float: string;
 }
 
-describe('FLOAT_SUM Database Function', () => {
-	let db: SQLiteWasmDatabase;
-	let perf: PerformanceTracker;
-	
-	beforeEach(async () => {
-		db = await createTestDatabase();
-		perf = new PerformanceTracker();
-		
-		await db.query(`
+describe("FLOAT_SUM Database Function", () => {
+  let db: SQLiteWasmDatabase;
+  let perf: PerformanceTracker;
+
+  function decodeFloatHex(hex: string): string {
+    const floatRes = Float.fromHex(hex as `0x${string}`);
+    if (floatRes.error) {
+      throw new Error(`fromHex failed: ${String(floatRes.error)}`);
+    }
+    const fmtRes = floatRes.value.format();
+    if (fmtRes.error) {
+      throw new Error(`format failed: ${String(fmtRes.error)}`);
+    }
+    return fmtRes.value as string;
+  }
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    perf = new PerformanceTracker();
+
+    await db.query(`
 			CREATE TABLE float_test (
 				id INTEGER PRIMARY KEY AUTOINCREMENT,
 				amount TEXT NOT NULL,
@@ -33,342 +46,364 @@ describe('FLOAT_SUM Database Function', () => {
 				description TEXT
 			)
 		`);
-	});
-	
-	afterEach(async () => {
-		await cleanupDatabase(db);
-	});
+  });
 
-	describe('Function Availability', () => {
-		it('should have FLOAT_SUM function available', async () => {
-			try {
-				const pragmaResult = await db.query('PRAGMA function_list');
-				expect(pragmaResult).toBeDefined();
-				const functions = JSON.parse(pragmaResult.value || '[]');
-				const floatSumEntry = functions.find((f: any) => f.name === 'FLOAT_SUM');
-				expect(floatSumEntry).toBeDefined();
-			} catch (error) {
-			}
+  afterEach(async () => {
+    await cleanupDatabase(db);
+  });
 
-			try {
-				const rainResult = await db.query('SELECT RAIN_MATH_PROCESS("100", "200") as test');
-				expect(rainResult).toBeDefined();
-				expect(rainResult.value).toBeDefined();
-			} catch (error) {
-				throw new Error('RAIN_MATH_PROCESS not available');
-			}
+  describe("Function Availability", () => {
+    it("should have FLOAT_SUM function available", async () => {
+      try {
+        const pragmaResult = await db.query("PRAGMA function_list");
+        expect(pragmaResult).toBeDefined();
+        const functions = JSON.parse(pragmaResult.value || "[]");
+        const floatSumEntry = functions.find(
+          (f: any) => f.name === "FLOAT_SUM",
+        );
+        expect(floatSumEntry).toBeDefined();
+      } catch (error) {}
 
-			try {
-				const result = await db.query('SELECT FLOAT_SUM("0xffffffff00000000000000000000000000000000000000000000000000000001") as test');
-				expect(result).toBeDefined();
-				expect(result.value).toBeDefined();
-				const data = JSON.parse(result.value || '[]');
-				expect(data[0].test).toBe('0.1');
-			} catch (error) {
-				throw new Error('FLOAT_SUM function not available');
-			}
-		});
-	});
+      try {
+        const rainResult = await db.query(
+          'SELECT RAIN_MATH_PROCESS("100", "200") as test',
+        );
+        expect(rainResult).toBeDefined();
+        expect(rainResult.value).toBeDefined();
+      } catch (error) {
+        throw new Error("RAIN_MATH_PROCESS not available");
+      }
 
-	describe('Basic FLOAT_SUM Functionality', () => {
-		beforeEach(async () => {
-			await db.query(`
-				INSERT INTO float_test (amount, category, description) VALUES 
+      try {
+        const result = await db.query(
+          'SELECT FLOAT_SUM("0xffffffff00000000000000000000000000000000000000000000000000000001") as test',
+        );
+        expect(result).toBeDefined();
+        expect(result.value).toBeDefined();
+        const data = JSON.parse(result.value || "[]");
+        const dec = decodeFloatHex(data[0].test);
+        expect(dec).toBe("0.1");
+      } catch (error) {
+        throw new Error("FLOAT_SUM function not available");
+      }
+    });
+  });
+
+  describe("Basic FLOAT_SUM Functionality", () => {
+    beforeEach(async () => {
+      await db.query(`
+				INSERT INTO float_test (amount, category, description) VALUES
 				('0xffffffff00000000000000000000000000000000000000000000000000000001', 'income', 'payment'),
 				('0xffffffff00000000000000000000000000000000000000000000000000000005', 'income', 'deposit'),
 				('ffffffff0000000000000000000000000000000000000000000000000000000f', 'income', 'amount')
 			`);
-		});
+    });
 
-		it('should sum positive float values correctly', async () => {
-			perf.start('float-sum-positive');
-			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
-			perf.end('float-sum-positive');
-			
-			const data = JSON.parse(result.value || '[]');
-			
-			expect(data).toHaveLength(1);
-			expect(data[0]).toHaveProperty('total');
-			
-			expect(data[0].total).toBe('2.1');
-			expect(perf.getDuration('float-sum-positive')).toBeLessThan(1000);
-		});
+    it("should sum positive float values correctly", async () => {
+      perf.start("float-sum-positive");
+      const result = await db.query(
+        "SELECT FLOAT_SUM(amount) as total FROM float_test",
+      );
+      perf.end("float-sum-positive");
 
-		it('should handle single row correctly', async () => {
-			await db.query('DELETE FROM float_test WHERE id > 1');
-			
-			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
-			const data = JSON.parse(result.value || '[]');
-			
-			expect(data[0].total).toBe('0.1');
-		});
+      const data = JSON.parse(result.value || "[]");
 
-		it('should return 0 for empty table', async () => {
-			await db.query('DELETE FROM float_test');
-			
-			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
-			const data = JSON.parse(result.value || '[]');
-			
-			expect(data[0].total).toBe('0');
-		});
-	});
+      expect(data).toHaveLength(1);
+      expect(data[0]).toHaveProperty("total");
 
-	describe('Hex Format Support', () => {
-		beforeEach(async () => {
-			await db.query(`
-				INSERT INTO float_test (amount, category, description) VALUES 
+      const dec = decodeFloatHex(data[0].total);
+      expect(dec).toBe("2.1");
+      expect(perf.getDuration("float-sum-positive")).toBeLessThan(1000);
+    });
+
+    it("should handle single row correctly", async () => {
+      await db.query("DELETE FROM float_test WHERE id > 1");
+
+      const result = await db.query(
+        "SELECT FLOAT_SUM(amount) as total FROM float_test",
+      );
+      const data = JSON.parse(result.value || "[]");
+
+      const dec = decodeFloatHex(data[0].total);
+      expect(dec).toBe("0.1");
+    });
+
+    it("should return 0 for empty table", async () => {
+      await db.query("DELETE FROM float_test");
+
+      const result = await db.query(
+        "SELECT FLOAT_SUM(amount) as total FROM float_test",
+      );
+      const data = JSON.parse(result.value || "[]");
+
+      const dec = decodeFloatHex(data[0].total);
+      expect(dec).toBe("0");
+    });
+  });
+
+  describe("Hex Format Support", () => {
+    beforeEach(async () => {
+      await db.query(`
+				INSERT INTO float_test (amount, category, description) VALUES
 				('0xfffffffe00000000000000000000000000000000000000000000000000002729', 'income', 'large payment'),
 				('fffffffd0000000000000000000000000000000000000000000000000001e240', 'income', 'large deposit'),
 				('0x0000000000000000000000000000000000000000000000000000000000000000', 'zero', 'zero value')
 			`);
-		});
+    });
 
-		it('should handle hex values with and without 0x prefix', async () => {
-			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
-			const data = JSON.parse(result.value || '[]');
-			
-			expect(data[0].total).toBe('223.706');
-		});
+    it("should handle hex values with and without 0x prefix", async () => {
+      const result = await db.query(
+        "SELECT FLOAT_SUM(amount) as total FROM float_test",
+      );
+      const data = JSON.parse(result.value || "[]");
 
-		it('should handle mixed case hex values', async () => {
-			await db.query('DELETE FROM float_test');
-			await db.query(`
-				INSERT INTO float_test (amount) VALUES 
+      const dec = decodeFloatHex(data[0].total);
+      expect(dec).toBe("223.706");
+    });
+
+    it("should handle mixed case hex values", async () => {
+      await db.query("DELETE FROM float_test");
+      await db.query(`
+				INSERT INTO float_test (amount) VALUES
 				('0xFfFfFfFf0000000000000000000000000000000000000000000000000000000F'),
 				('0xFfFfFfFe000000000000000000000000000000000000000000000000000000E1')
 			`);
-			
-			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
-			const data = JSON.parse(result.value || '[]');
-			
-			expect(data[0].total).toBe('3.75');
-		});
 
-		it('should reject uppercase 0X prefix', async () => {
-			await db.query('DELETE FROM float_test');
-			await db.query(`
+      const result = await db.query(
+        "SELECT FLOAT_SUM(amount) as total FROM float_test",
+      );
+      const data = JSON.parse(result.value || "[]");
+
+      const dec = decodeFloatHex(data[0].total);
+      expect(dec).toBe("3.75");
+    });
+
+    it("should reject uppercase 0X prefix", async () => {
+      await db.query("DELETE FROM float_test");
+      await db.query(`
 				INSERT INTO float_test (amount) VALUES ('0XFFFFFFFB0000000000000000000000000000000000000000000000000004CB2F')
 			`);
-			
-			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
-			expect(result.error).toBeDefined();
-			expect(result.error?.msg).toContain('Failed to parse hex number');
-		});
-	});
 
-	describe('GROUP BY Operations', () => {
-		beforeEach(async () => {
-			await db.query(`
-				INSERT INTO float_test (amount, category) VALUES 
+      const result = await db.query(
+        "SELECT FLOAT_SUM(amount) as total FROM float_test",
+      );
+      expect(result.error).toBeDefined();
+      expect(result.error?.msg).toContain("Failed to parse hex number");
+    });
+  });
+
+  describe("GROUP BY Operations", () => {
+    beforeEach(async () => {
+      await db.query(`
+				INSERT INTO float_test (amount, category) VALUES
 				('0xffffffff00000000000000000000000000000000000000000000000000000001', 'income'),
 				('0xffffffff00000000000000000000000000000000000000000000000000000005', 'income'),
 				('0x000000000000000000000000000000000000000000000000000000000000000a', 'bonus'),
 				('ffffffff0000000000000000000000000000000000000000000000000000000f', 'expense')
 			`);
-		});
+    });
 
-		it('should work with GROUP BY clauses', async () => {
-			const result = await db.query(`
-				SELECT category, FLOAT_SUM(amount) as total 
-				FROM float_test 
-				GROUP BY category 
-				ORDER BY category
-			`);
-			const data = JSON.parse(result.value || '[]');
-			
-			expect(data).toHaveLength(3);
-			
-			const bonus = data.find((row: CategoryRow) => row.category === 'bonus');
-			const expense = data.find((row: CategoryRow) => row.category === 'expense');
-			const income = data.find((row: CategoryRow) => row.category === 'income');
-			
-			expect(bonus?.total).toBe('10');
-			expect(expense?.total).toBe('1.5');
-			expect(income?.total).toBe('0.6');
-		});
+    it("should work with GROUP BY clauses", async () => {
+      const result = await db.query(`
+                SELECT category, FLOAT_SUM(amount) as total
+                FROM float_test
+                GROUP BY category
+                ORDER BY category
+            `);
+      const data = JSON.parse(result.value || "[]");
 
-		it('should work with HAVING clauses', async () => {
-			const result = await db.query(`
-				SELECT category, FLOAT_SUM(amount) as total 
-				FROM float_test 
-				GROUP BY category 
-				HAVING FLOAT_SUM(amount) > '1'
-				ORDER BY total DESC
-			`);
-			const data = JSON.parse(result.value || '[]');
-			
-			expect(data).toHaveLength(2);
-			const categories = data.map((row: CategoryRow) => row.category).sort();
-			expect(categories).toEqual(['bonus', 'expense']);
-		});
-	});
+      expect(data).toHaveLength(3);
 
-	describe('Error Handling', () => {
-		it('should handle invalid hex strings gracefully', async () => {
-			await db.query(`
+      const bonus = data.find((row: CategoryRow) => row.category === "bonus");
+      const expense = data.find(
+        (row: CategoryRow) => row.category === "expense",
+      );
+      const income = data.find((row: CategoryRow) => row.category === "income");
+
+      const bonusDec = decodeFloatHex(bonus!.total);
+      const expenseDec = decodeFloatHex(expense!.total);
+      const incomeDec = decodeFloatHex(income!.total);
+
+      expect(bonusDec).toBe("10");
+      expect(expenseDec).toBe("1.5");
+      expect(incomeDec).toBe("0.6");
+    });
+
+    it("should filter groups by decoded sum (> 1)", async () => {
+      const result = await db.query(`
+                SELECT category, FLOAT_SUM(amount) as total
+                FROM float_test
+                GROUP BY category
+                ORDER BY category
+            `);
+      const data = JSON.parse(result.value || "[]");
+
+      const filtered = [] as string[];
+      for (const row of data as CategoryRow[]) {
+        const dec = decodeFloatHex(row.total);
+        if (Number(dec) > 1) filtered.push(row.category);
+      }
+      filtered.sort();
+      expect(filtered).toEqual(["bonus", "expense"]);
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("should handle invalid hex strings gracefully", async () => {
+      await db.query(`
 				INSERT INTO float_test (amount) VALUES ('not_hex')
 			`);
-			
-			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
-			expect(result.error).toBeDefined();
-			expect(result.error?.msg).toContain('Failed to parse hex number');
-		});
 
-		it('should handle empty strings gracefully', async () => {
-			await db.query(`
+      const result = await db.query(
+        "SELECT FLOAT_SUM(amount) as total FROM float_test",
+      );
+      expect(result.error).toBeDefined();
+      expect(result.error?.msg).toContain("Failed to parse hex number");
+    });
+
+    it("should handle empty strings gracefully", async () => {
+      await db.query(`
 				INSERT INTO float_test (amount) VALUES ('')
 			`);
-			
-			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
-			expect(result.error).toBeDefined();
-			expect(result.error?.msg).toContain('Empty string is not a valid hex number');
-		});
 
-		it('should handle invalid hex characters', async () => {
-			await db.query(`
+      const result = await db.query(
+        "SELECT FLOAT_SUM(amount) as total FROM float_test",
+      );
+      expect(result.error).toBeDefined();
+      expect(result.error?.msg).toContain(
+        "Empty string is not a valid hex number",
+      );
+    });
+
+    it("should handle invalid hex characters", async () => {
+      await db.query(`
 				INSERT INTO float_test (amount) VALUES ('0xGHI')
 			`);
-			
-			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
-			expect(result.error).toBeDefined();
-			expect(result.error?.msg).toContain('Failed to parse hex number');
-		});
 
-		it('should handle only valid hex values', async () => {
-			await db.query(`
-				INSERT INTO float_test (amount) VALUES 
+      const result = await db.query(
+        "SELECT FLOAT_SUM(amount) as total FROM float_test",
+      );
+      expect(result.error).toBeDefined();
+      expect(result.error?.msg).toContain("Failed to parse hex number");
+    });
+
+    it("should handle only valid hex values", async () => {
+      await db.query(`
+				INSERT INTO float_test (amount) VALUES
 				('0xffffffff00000000000000000000000000000000000000000000000000000001'),
 				('0xffffffff00000000000000000000000000000000000000000000000000000005')
 			`);
-			
-			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
-			const data = JSON.parse(result.value || '[]');
-			
-			expect(data[0].total).toBe('0.6');
-		});
-	});
 
-	describe('Edge Cases and Limits', () => {
-		it('should handle very small float values', async () => {
-			const smallValue = '0xffffffff00000000000000000000000000000000000000000000000000000001';
-			
-			await db.query(`
+      const result = await db.query(
+        "SELECT FLOAT_SUM(amount) as total FROM float_test",
+      );
+      const data = JSON.parse(result.value || "[]");
+
+      const dec = decodeFloatHex(data[0].total);
+      expect(dec).toBe("0.6");
+    });
+  });
+
+  describe("Edge Cases and Limits", () => {
+    it("should handle very small float values", async () => {
+      const smallValue =
+        "0xffffffff00000000000000000000000000000000000000000000000000000001";
+
+      await db.query(`
 				INSERT INTO float_test (amount) VALUES ('${smallValue}')
 			`);
-			
-			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
-			const data = JSON.parse(result.value || '[]');
-			
-			expect(data[0].total).toBe('0.1');
-		});
 
-		it('should reject hex values that are too short', async () => {
-			await db.query(`
+      const result = await db.query(
+        "SELECT FLOAT_SUM(amount) as total FROM float_test",
+      );
+      const data = JSON.parse(result.value || "[]");
+
+      const dec = decodeFloatHex(data[0].total);
+      expect(dec).toBe("0.1");
+    });
+
+    it("should reject hex values that are too short", async () => {
+      await db.query(`
 				INSERT INTO float_test (amount) VALUES ('0x0')
 			`);
-			
-			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
-			expect(result.error).toBeDefined();
-			expect(result.error?.msg).toContain('Failed to parse hex number');
-		});
 
-		it('should handle whitespace in hex values', async () => {
-			await db.query(`
-				INSERT INTO float_test (amount) VALUES 
+      const result = await db.query(
+        "SELECT FLOAT_SUM(amount) as total FROM float_test",
+      );
+      expect(result.error).toBeDefined();
+      expect(result.error?.msg).toContain("Failed to parse hex number");
+    });
+
+    it("should handle whitespace in hex values", async () => {
+      await db.query(`
+				INSERT INTO float_test (amount) VALUES
 				('  0x000000000000000000000000000000000000000000000000000000000000000a  '),
 				('\t0x0000000000000000000000000000000000000000000000000000000000000014\n')
 			`);
-			
-			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
-			const data = JSON.parse(result.value || '[]');
-			
-			expect(data[0].total).toBe('30');
-		});
-	});
 
-	describe('High Precision Decimals', () => {
-		beforeEach(async () => {
-			await db.query(`
-				INSERT INTO float_test (amount, category, description) VALUES 
-				('0xffffffee0000000000000000000000000000000000000010450cb5d3cf60f34e', 'precision', 'high precision 1'),
-				('0xffffffee0000000000000000000000000000000000000010510af4e77328b478', 'precision', 'high precision 2'),
-				('0xffffffee00000000000000000000000000000000000000104b0bd55dbf1238e3', 'precision', 'high precision 3'),
-				('0xffffffee00000000000000000000000000000000000000104e21534cc7d31c71', 'precision', 'high precision 4'),
-				('0xffffffee00000000000000000000000000000000000000105136d13bd093ffff', 'precision', 'high precision 5')
-			`);
-		});
+      const result = await db.query(
+        "SELECT FLOAT_SUM(amount) as total FROM float_test",
+      );
+      const data = JSON.parse(result.value || "[]");
 
-		it('should handle high precision decimal calculations', async () => {
-			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
-			const data = JSON.parse(result.value || '[]');
-			
-			expect(data[0].total).toBe('1503.444444443444444441');
-		});
+      const dec = decodeFloatHex(data[0].total);
+      expect(dec).toBe("30");
+    });
+  });
 
-		it('should handle mixed precision values correctly', async () => {
-			await db.query('DELETE FROM float_test');
-			await db.query(`
-				INSERT INTO float_test (amount) VALUES 
-				('0xffffffee00000000000000000000000000000000000000000f9751ff4d94f34e'),
-				('0xffffffee0000000000000000000000000000000000000000297647c698c0b478'),
-				('0x0000000000000000000000000000000000000000000000000000000000000064')
-			`);
-			
-			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
-			const data = JSON.parse(result.value || '[]');
-			
-			expect(data[0].total).toBe('104.11111111011111111');
-		});
-	});
+  describe("Performance Tests", () => {
+    it("should handle bulk aggregation efficiently", async () => {
+      const values = Array.from(
+        { length: 10 },
+        (_, i) =>
+          `('0xffffffff00000000000000000000000000000000000000000000000000000001', 'bulk')`,
+      ).join(",");
 
-	describe('Performance Tests', () => {
-		it('should handle bulk aggregation efficiently', async () => {
-			const values = Array.from({ length: 10 }, (_, i) => 
-				`('0xffffffff00000000000000000000000000000000000000000000000000000001', 'bulk')`
-			).join(',');
-			
-			await db.query(`
+      await db.query(`
 				INSERT INTO float_test (amount, category) VALUES ${values}
 			`);
-			
-			perf.start('bulk-float-sum');
-			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
-			perf.end('bulk-float-sum');
-			
-			if (result.error) {
-				throw new Error(`Query failed: ${result.error.msg}`);
-			}
-			
-			const data = JSON.parse(result.value || '[]');
-			expect(data).toHaveLength(1);
-			expect(data[0]).toHaveProperty('total');
-			expect(data[0].total).toBe('1');
-			expect(perf.getDuration('bulk-float-sum')).toBeLessThan(3000);
-		});
 
-		it('should handle complex queries with joins efficiently', async () => {
-			await db.query(`
+      perf.start("bulk-float-sum");
+      const result = await db.query(
+        "SELECT FLOAT_SUM(amount) as total FROM float_test",
+      );
+      perf.end("bulk-float-sum");
+
+      if (result.error) {
+        throw new Error(`Query failed: ${result.error.msg}`);
+      }
+
+      const data = JSON.parse(result.value || "[]");
+      expect(data).toHaveLength(1);
+      expect(data[0]).toHaveProperty("total");
+      const dec = decodeFloatHex(data[0].total);
+      expect(dec).toBe("1");
+      expect(perf.getDuration("bulk-float-sum")).toBeLessThan(3000);
+    });
+
+    it("should handle complex queries with joins efficiently", async () => {
+      await db.query(`
 				CREATE TABLE float_categories (
 					name TEXT PRIMARY KEY,
 					multiplier TEXT
 				)
 			`);
-			
-			await db.query(`
-				INSERT INTO float_categories (name, multiplier) VALUES 
+
+      await db.query(`
+				INSERT INTO float_categories (name, multiplier) VALUES
 				('income', '2'),
 				('expense', '1')
 			`);
-			
-			await db.query(`
-				INSERT INTO float_test (amount, category) VALUES 
+
+      await db.query(`
+				INSERT INTO float_test (amount, category) VALUES
 				('0xffffffff00000000000000000000000000000000000000000000000000000001', 'income'),
 				('0xffffffff00000000000000000000000000000000000000000000000000000005', 'expense')
 			`);
-			
-			perf.start('complex-float-query');
-			const result = await db.query(`
-				SELECT 
+
+      perf.start("complex-float-query");
+      const result = await db.query(`
+				SELECT
 					t.category,
 					FLOAT_SUM(t.amount) as total_amount,
 					c.multiplier
@@ -377,106 +412,121 @@ describe('FLOAT_SUM Database Function', () => {
 				GROUP BY t.category, c.multiplier
 				ORDER BY total_amount DESC
 			`);
-			perf.end('complex-float-query');
-			
-			const data = JSON.parse(result.value || '[]');
-			expect(Array.isArray(data)).toBe(true);
-			expect(data.length).toBe(2);
-			
-			const rowsByCategory = data.reduce((map: Record<string, any>, row: any) => {
-				map[row.category] = row;
-				return map;
-			}, {} as Record<string, any>);
-			
-			expect(rowsByCategory['income']).toBeDefined();
-			expect(rowsByCategory['income'].total_amount).toBe('0.1');
-			expect(rowsByCategory['income'].multiplier).toBe('2');
-			
-			expect(rowsByCategory['expense']).toBeDefined();
-			expect(rowsByCategory['expense'].total_amount).toBe('0.5');
-			expect(rowsByCategory['expense'].multiplier).toBe('1');
-			
-			expect(perf.getDuration('complex-float-query')).toBeLessThan(2000);
-		});
-	});
+      perf.end("complex-float-query");
 
-	describe('Real-world Scenarios', () => {
-		it('should handle DeFi-like transaction amounts', async () => {
-			await db.query(`
-				INSERT INTO float_test (amount, category, description) VALUES 
+      const data = JSON.parse(result.value || "[]");
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBe(2);
+
+      const rowsByCategory = data.reduce(
+        (map: Record<string, any>, row: any) => {
+          map[row.category] = row;
+          return map;
+        },
+        {} as Record<string, any>,
+      );
+
+      expect(rowsByCategory["income"]).toBeDefined();
+      expect(decodeFloatHex(rowsByCategory["income"].total_amount)).toBe("0.1");
+      expect(rowsByCategory["income"].multiplier).toBe("2");
+
+      expect(rowsByCategory["expense"]).toBeDefined();
+      expect(decodeFloatHex(rowsByCategory["expense"].total_amount)).toBe(
+        "0.5",
+      );
+      expect(rowsByCategory["expense"].multiplier).toBe("1");
+
+      expect(perf.getDuration("complex-float-query")).toBeLessThan(2000);
+    });
+  });
+
+  describe("Real-world Scenarios", () => {
+    it("should handle DeFi-like transaction amounts", async () => {
+      await db.query(`
+				INSERT INTO float_test (amount, category, description) VALUES
 				('0xfffffffe00000000000000000000000000000000000000000000000000002729', 'swap', 'token swap'),
 				('0xfffffffd0000000000000000000000000000000000000000000000000001e240', 'liquidity', 'liquidity provision'),
 				('0xffffffff00000000000000000000000000000000000000000000000000000001', 'rewards', 'staking rewards'),
 				('0xffffffff00000000000000000000000000000000000000000000000000000005', 'fees', 'protocol fees')
 			`);
-			
-			const result = await db.query(`
-				SELECT 
+
+      const result = await db.query(`
+				SELECT
 					category,
 					FLOAT_SUM(amount) as total_float,
 					COUNT(*) as transaction_count
-				FROM float_test 
+				FROM float_test
 				GROUP BY category
 				ORDER BY total_float DESC
 			`);
-			
-			const data = JSON.parse(result.value || '[]');
-			expect(Array.isArray(data)).toBe(true);
-			
-			const liquidity = data.find((row: TransactionRow) => row.category === 'liquidity');
-			expect(liquidity?.total_float).toBe('123.456');
-		});
 
-		it('should handle precision accounting that must balance', async () => {
-			await db.query(`
-				INSERT INTO float_test (amount, description) VALUES 
+      const data = JSON.parse(result.value || "[]");
+      expect(Array.isArray(data)).toBe(true);
+
+      const liquidity = data.find(
+        (row: TransactionRow) => row.category === "liquidity",
+      );
+      expect(decodeFloatHex(liquidity!.total_float)).toBe("123.456");
+    });
+
+    it("should handle precision accounting that must balance", async () => {
+      await db.query(`
+				INSERT INTO float_test (amount, description) VALUES
 				('0xfffffffe00000000000000000000000000000000000000000000000000002729', 'Initial balance'),
 				('0xffffffff00000000000000000000000000000000000000000000000000000001', 'Small addition')
 			`);
-			
-			const result = await db.query('SELECT FLOAT_SUM(amount) as balance FROM float_test');
-			
-			if (result.error) {
-				throw new Error(`Query failed: ${result.error.msg}`);
-			}
-			
-			const data = JSON.parse(result.value || '[]');
-			expect(data).toHaveLength(1);
-			expect(data[0]).toHaveProperty('balance');
-			expect(data[0].balance).toBe('100.35');
-		});
-	});
 
-	describe('NULL Value Handling', () => {
-		it('should skip NULL values like standard SQL aggregates', async () => {
-			await db.query(`
-				INSERT INTO float_test (amount, category) VALUES 
+      const result = await db.query(
+        "SELECT FLOAT_SUM(amount) as balance FROM float_test",
+      );
+
+      if (result.error) {
+        throw new Error(`Query failed: ${result.error.msg}`);
+      }
+
+      const data = JSON.parse(result.value || "[]");
+      expect(data).toHaveLength(1);
+      expect(data[0]).toHaveProperty("balance");
+      const dec = decodeFloatHex(data[0].balance);
+      expect(dec).toBe("100.35");
+    });
+  });
+
+  describe("NULL Value Handling", () => {
+    it("should skip NULL values like standard SQL aggregates", async () => {
+      await db.query(`
+				INSERT INTO float_test (amount, category) VALUES
 				('0xffffffff00000000000000000000000000000000000000000000000000000001', 'test'),
 				('0xffffffff00000000000000000000000000000000000000000000000000000005', 'test')
 			`);
-			
-			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
-			
-			if (result.error) {
-				throw new Error(`Query failed: ${result.error.msg}`);
-			}
-			
-			const data = JSON.parse(result.value || '[]');
-			expect(data).toHaveLength(1);
-			expect(data[0].total).toBe('0.6');
-		});
 
-		it('should return 0 when all values are NULL', async () => {
-			await db.query(`
-				INSERT INTO float_test (amount, category) VALUES 
+      const result = await db.query(
+        "SELECT FLOAT_SUM(amount) as total FROM float_test",
+      );
+
+      if (result.error) {
+        throw new Error(`Query failed: ${result.error.msg}`);
+      }
+
+      const data = JSON.parse(result.value || "[]");
+      expect(data).toHaveLength(1);
+      const dec = decodeFloatHex(data[0].total);
+      expect(dec).toBe("0.6");
+    });
+
+    it("should return 0 when all values are NULL", async () => {
+      await db.query(`
+				INSERT INTO float_test (amount, category) VALUES
 				(NULL, 'test'),
 				(NULL, 'test')
 			`);
-			
-			const result = await db.query('SELECT FLOAT_SUM(amount) as total FROM float_test');
-			const data = JSON.parse(result.value || '[]');
-			
-			expect(data[0].total).toBe('0');
-		});
-	});
+
+      const result = await db.query(
+        "SELECT FLOAT_SUM(amount) as total FROM float_test",
+      );
+      const data = JSON.parse(result.value || "[]");
+      const dec = decodeFloatHex(data[0].total);
+      expect(dec).toBe("0");
+    });
+  });
 });

--- a/svelte-test/tests/fixtures/test-helpers.ts
+++ b/svelte-test/tests/fixtures/test-helpers.ts
@@ -186,7 +186,7 @@ export async function cleanupDatabase(db: SQLiteWasmDatabase): Promise<void> {
 			// Worker communication test tables  
 			'workers_test', 'shared_data', 'worker_coordination', 'message_test',
 			// Database function test tables
-			'bigint_test', 'categories'
+			'bigint_test', 'categories', 'float_test', 'float_categories'
 		];
 		for (const table of tables) {
 			try {


### PR DESCRIPTION
> [!CAUTION]
> Chained PR. Do not merge before https://github.com/rainlanguage/sqlite-web/pull/5
> Change base branch before merge.

<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

This PR adds the sum logic for Float type numbers.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

fix https://github.com/rainlanguage/rain.orderbook/issues/2074

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added FLOAT_SUM SQLite aggregate for summing hex-encoded floats. Handles 0x/no-prefix, trims whitespace, ignores NULLs, returns 0 for empty sets, supports GROUP BY, and rejects invalid formats (e.g., uppercase "0X") with descriptive errors.
- Tests
  - Comprehensive test suite validating availability, correctness, grouping, error cases, edge limits, performance, and real-world scenarios.
- Chores
  - Added @rainlanguage/float dependency and expanded test cleanup to drop float-related tables.
- Bug Fixes
  - Improved finalization/memory handling for BIGINT_SUM (behavior preserved).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->